### PR TITLE
Fix GoReleaser out-of-disk issue

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -26,6 +26,10 @@ builds:
   - darwin
   - windows
   - linux
+  hooks:
+    post:
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version.Version={{.Tag}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,10 @@ builds:
   - darwin
   - windows
   - linux
+  hooks:
+    post:
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -cache
+    - env GOOS={{ .Os }} GOARCH={{ .Arch }} go clean -modcache
   ignore: []
   ldflags:
   - -X github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version.Version={{.Tag}}


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi-azure/pull/1290, attempting to resolve out-of-disk failures such as https://github.com/pulumi/pulumi-alicloud/actions/runs/5742067956/job/15563964146.

Will add changes to `ci-mgmt` if successful.