### PR TITLE
gci linter: sort imports

### DIFF
--- a/provider/cmd/pulumi-resource-alicloud/main.go
+++ b/provider/cmd/pulumi-resource-alicloud/main.go
@@ -19,9 +19,10 @@ package main
 import (
 	_ "embed"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+
 	alicloud "github.com/pulumi/pulumi-alicloud/provider/v3"
 	"github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 )
 
 //go:embed schema-embed.json

--- a/provider/cmd/pulumi-tfgen-alicloud/main.go
+++ b/provider/cmd/pulumi-tfgen-alicloud/main.go
@@ -15,9 +15,10 @@
 package main
 
 import (
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+
 	alicloud "github.com/pulumi/pulumi-alicloud/provider/v3"
 	"github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
 )
 
 func main() {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -16,20 +16,23 @@ package alicloud
 
 import (
 	"fmt"
-	// embed is used to store bridge-metadata.json in the compiled binary
-	_ "embed"
 	"path/filepath"
 	"strings"
 	"unicode"
 
+	// embed is used to store bridge-metadata.json in the compiled binary
+	_ "embed"
+
 	"github.com/aliyun/terraform-provider-alicloud/alicloud"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/x"
 	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-alicloud/provider/v3/pkg/version"
 )
 
 // all of the AliCloud token components used below.


### PR DESCRIPTION
This PR is part of a migration to standardize the order and grouping of our Go imports. See https://github.com/pulumi/upgrade-provider/pull/236.