### PR TITLE
Fix example skipping for FC resources

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2525,10 +2525,6 @@ func Provider() tfbridge.ProviderInfo {
 			"alicloud_cms_monitor_group_instances",
 			"alicloud_dataworks_service",
 		},
-		SkipExamples: func(args tfbridge.SkipExamplesArgs) bool {
-			// Blocked by https://github.com/pulumi/pulumi/issues/13886
-			return args.Token == "alicloud:fc/service:Service" || args.Token == "alicloud:fc/v2Function:V2Function"
-		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			DevDependencies: map[string]string{
 				"@types/node": "^10.0.0", // so we can access strongly typed node definitions.

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -2590,6 +2590,9 @@ func docEditRules(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
 		removeContent(versionNote, "index.html.markdown"),
 		removeContent(configurationSource, "index.html.markdown"),
 		skipUserAgentSection,
+		// TODO: remove when https://github.com/pulumi/pulumi/issues/13886.
+		skipExamplesSection("fc_service.html.markdown"),
+		skipExamplesSection("fcv2_function.html.markdown"),
 	)
 }
 
@@ -2601,6 +2604,17 @@ var skipUserAgentSection = tfbridge.DocsEdit{
 			return headerText == "Custom User-Agent Information"
 		})
 	},
+}
+
+func skipExamplesSection(path string) tfbridge.DocsEdit {
+	return tfbridge.DocsEdit{
+		Path: path,
+		Edit: func(_ string, content []byte) ([]byte, error) {
+			return tfgen.SkipSectionByHeaderContent(content, func(headerText string) bool {
+				return headerText == "Example Usage"
+			})
+		},
+	}
 }
 
 // Removes a reference to TF version and compatibility

--- a/sdk/dotnet/FC/GetService.cs
+++ b/sdk/dotnet/FC/GetService.cs
@@ -17,24 +17,6 @@ namespace Pulumi.AliCloud.FC
         /// For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
         /// 
         /// &gt; **NOTE:** Available since v1.112.0+
-        /// 
-        /// ## Example Usage
-        /// 
-        /// ```csharp
-        /// using System.Collections.Generic;
-        /// using System.Linq;
-        /// using Pulumi;
-        /// using AliCloud = Pulumi.AliCloud;
-        /// 
-        /// return await Deployment.RunAsync(() =&gt; 
-        /// {
-        ///     var open = AliCloud.FC.GetService.Invoke(new()
-        ///     {
-        ///         Enable = "On",
-        ///     });
-        /// 
-        /// });
-        /// ```
         /// </summary>
         public static Task<GetServiceResult> InvokeAsync(GetServiceArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.InvokeAsync<GetServiceResult>("alicloud:fc/getService:getService", args ?? new GetServiceArgs(), options.WithDefaults());
@@ -45,24 +27,6 @@ namespace Pulumi.AliCloud.FC
         /// For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
         /// 
         /// &gt; **NOTE:** Available since v1.112.0+
-        /// 
-        /// ## Example Usage
-        /// 
-        /// ```csharp
-        /// using System.Collections.Generic;
-        /// using System.Linq;
-        /// using Pulumi;
-        /// using AliCloud = Pulumi.AliCloud;
-        /// 
-        /// return await Deployment.RunAsync(() =&gt; 
-        /// {
-        ///     var open = AliCloud.FC.GetService.Invoke(new()
-        ///     {
-        ///         Enable = "On",
-        ///     });
-        /// 
-        /// });
-        /// ```
         /// </summary>
         public static Output<GetServiceResult> Invoke(GetServiceInvokeArgs? args = null, InvokeOptions? options = null)
             => global::Pulumi.Deployment.Instance.Invoke<GetServiceResult>("alicloud:fc/getService:getService", args ?? new GetServiceInvokeArgs(), options.WithDefaults());
@@ -73,24 +37,6 @@ namespace Pulumi.AliCloud.FC
         /// For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
         /// 
         /// &gt; **NOTE:** Available since v1.112.0+
-        /// 
-        /// ## Example Usage
-        /// 
-        /// ```csharp
-        /// using System.Collections.Generic;
-        /// using System.Linq;
-        /// using Pulumi;
-        /// using AliCloud = Pulumi.AliCloud;
-        /// 
-        /// return await Deployment.RunAsync(() =&gt; 
-        /// {
-        ///     var open = AliCloud.FC.GetService.Invoke(new()
-        ///     {
-        ///         Enable = "On",
-        ///     });
-        /// 
-        /// });
-        /// ```
         /// </summary>
         public static Output<GetServiceResult> Invoke(GetServiceInvokeArgs args, InvokeOutputOptions options)
             => global::Pulumi.Deployment.Instance.Invoke<GetServiceResult>("alicloud:fc/getService:getService", args ?? new GetServiceInvokeArgs(), options.WithDefaults());

--- a/sdk/dotnet/FC/Inputs/ServiceTracingConfigArgs.cs
+++ b/sdk/dotnet/FC/Inputs/ServiceTracingConfigArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.AliCloud.FC.Inputs
         private InputMap<string>? _params;
 
         /// <summary>
-        /// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        /// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
         /// </summary>
         public InputMap<string> Params
         {

--- a/sdk/dotnet/FC/Inputs/ServiceTracingConfigGetArgs.cs
+++ b/sdk/dotnet/FC/Inputs/ServiceTracingConfigGetArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.AliCloud.FC.Inputs
         private InputMap<string>? _params;
 
         /// <summary>
-        /// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        /// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
         /// </summary>
         public InputMap<string> Params
         {

--- a/sdk/dotnet/FC/Outputs/ServiceTracingConfig.cs
+++ b/sdk/dotnet/FC/Outputs/ServiceTracingConfig.cs
@@ -14,7 +14,7 @@ namespace Pulumi.AliCloud.FC.Outputs
     public sealed class ServiceTracingConfig
     {
         /// <summary>
-        /// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        /// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
         /// </summary>
         public readonly ImmutableDictionary<string, string> Params;
         /// <summary>

--- a/sdk/dotnet/FC/Service.cs
+++ b/sdk/dotnet/FC/Service.cs
@@ -9,48 +9,115 @@ using Pulumi.Serialization;
 
 namespace Pulumi.AliCloud.FC
 {
+    /// <summary>
+    /// Provides a Alicloud Function Compute Service resource. The resource is the base of launching Function and Trigger configuration.
+    /// For information about Service and how to use it, see [What is Function Compute](https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-createservice).
+    /// 
+    /// &gt; **NOTE:** The resource requires a provider field 'account_id'. See account_id.
+    /// 
+    /// &gt; **NOTE:** If you happen the error "Argument 'internetAccess' is not supported", you need to log on web console and click button "Apply VPC Function"
+    /// which is in the upper of [Function Service Web Console](https://fc.console.aliyun.com/) page.
+    /// 
+    /// &gt; **NOTE:** Currently not all regions support Function Compute Service.
+    /// For more details supported regions, see [Service endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm)
+    /// 
+    /// &gt; **NOTE:** Available since v1.93.0.
+    /// ## Module Support
+    /// 
+    /// You can use to the existing fc module to create a service and a function quickly and then set several triggers for it.
+    /// 
+    /// ## Import
+    /// 
+    /// Function Compute Service can be imported using the id or name, e.g.
+    /// 
+    /// ```sh
+    /// $ pulumi import alicloud:fc/service:Service foo my-fc-service
+    /// ```
+    /// </summary>
     [AliCloudResourceType("alicloud:fc/service:Service")]
     public partial class Service : global::Pulumi.CustomResource
     {
+        /// <summary>
+        /// The Function Compute Service description.
+        /// </summary>
         [Output("description")]
         public Output<string?> Description { get; private set; } = null!;
 
+        /// <summary>
+        /// Whether to allow the Service to access Internet. Default to "true".
+        /// </summary>
         [Output("internetAccess")]
         public Output<bool?> InternetAccess { get; private set; } = null!;
 
+        /// <summary>
+        /// The date this resource was last modified.
+        /// </summary>
         [Output("lastModified")]
         public Output<string> LastModified { get; private set; } = null!;
 
+        /// <summary>
+        /// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        /// </summary>
         [Output("logConfig")]
         public Output<Outputs.ServiceLogConfig?> LogConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        /// </summary>
         [Output("name")]
         public Output<string> Name { get; private set; } = null!;
 
+        /// <summary>
+        /// Setting a prefix to get a only name. It is conflict with `name`.
+        /// </summary>
         [Output("namePrefix")]
         public Output<string?> NamePrefix { get; private set; } = null!;
 
+        /// <summary>
+        /// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        /// </summary>
         [Output("nasConfig")]
         public Output<Outputs.ServiceNasConfig?> NasConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        /// </summary>
         [Output("publish")]
         public Output<bool?> Publish { get; private set; } = null!;
 
+        /// <summary>
+        /// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        /// </summary>
         [Output("role")]
         public Output<string?> Role { get; private set; } = null!;
 
+        /// <summary>
+        /// The Function Compute Service ID.
+        /// </summary>
         [Output("serviceId")]
         public Output<string> ServiceId { get; private set; } = null!;
 
+        /// <summary>
+        /// Map for tagging resources.
+        /// </summary>
         [Output("tags")]
         public Output<ImmutableDictionary<string, string>?> Tags { get; private set; } = null!;
 
+        /// <summary>
+        /// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        /// </summary>
         [Output("tracingConfig")]
         public Output<Outputs.ServiceTracingConfig?> TracingConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// The latest published version of your Function Compute Service.
+        /// </summary>
         [Output("version")]
         public Output<string> Version { get; private set; } = null!;
 
+        /// <summary>
+        /// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+        /// </summary>
         [Output("vpcConfig")]
         public Output<Outputs.ServiceVpcConfig?> VpcConfig { get; private set; } = null!;
 
@@ -100,41 +167,75 @@ namespace Pulumi.AliCloud.FC
 
     public sealed class ServiceArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The Function Compute Service description.
+        /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
 
+        /// <summary>
+        /// Whether to allow the Service to access Internet. Default to "true".
+        /// </summary>
         [Input("internetAccess")]
         public Input<bool>? InternetAccess { get; set; }
 
+        /// <summary>
+        /// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        /// </summary>
         [Input("logConfig")]
         public Input<Inputs.ServiceLogConfigArgs>? LogConfig { get; set; }
 
+        /// <summary>
+        /// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }
 
+        /// <summary>
+        /// Setting a prefix to get a only name. It is conflict with `name`.
+        /// </summary>
         [Input("namePrefix")]
         public Input<string>? NamePrefix { get; set; }
 
+        /// <summary>
+        /// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        /// </summary>
         [Input("nasConfig")]
         public Input<Inputs.ServiceNasConfigArgs>? NasConfig { get; set; }
 
+        /// <summary>
+        /// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        /// </summary>
         [Input("publish")]
         public Input<bool>? Publish { get; set; }
 
+        /// <summary>
+        /// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        /// </summary>
         [Input("role")]
         public Input<string>? Role { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;
+
+        /// <summary>
+        /// Map for tagging resources.
+        /// </summary>
         public InputMap<string> Tags
         {
             get => _tags ?? (_tags = new InputMap<string>());
             set => _tags = value;
         }
 
+        /// <summary>
+        /// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        /// </summary>
         [Input("tracingConfig")]
         public Input<Inputs.ServiceTracingConfigArgs>? TracingConfig { get; set; }
 
+        /// <summary>
+        /// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+        /// </summary>
         [Input("vpcConfig")]
         public Input<Inputs.ServiceVpcConfigArgs>? VpcConfig { get; set; }
 
@@ -146,50 +247,93 @@ namespace Pulumi.AliCloud.FC
 
     public sealed class ServiceState : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The Function Compute Service description.
+        /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
 
+        /// <summary>
+        /// Whether to allow the Service to access Internet. Default to "true".
+        /// </summary>
         [Input("internetAccess")]
         public Input<bool>? InternetAccess { get; set; }
 
+        /// <summary>
+        /// The date this resource was last modified.
+        /// </summary>
         [Input("lastModified")]
         public Input<string>? LastModified { get; set; }
 
+        /// <summary>
+        /// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        /// </summary>
         [Input("logConfig")]
         public Input<Inputs.ServiceLogConfigGetArgs>? LogConfig { get; set; }
 
+        /// <summary>
+        /// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        /// </summary>
         [Input("name")]
         public Input<string>? Name { get; set; }
 
+        /// <summary>
+        /// Setting a prefix to get a only name. It is conflict with `name`.
+        /// </summary>
         [Input("namePrefix")]
         public Input<string>? NamePrefix { get; set; }
 
+        /// <summary>
+        /// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        /// </summary>
         [Input("nasConfig")]
         public Input<Inputs.ServiceNasConfigGetArgs>? NasConfig { get; set; }
 
+        /// <summary>
+        /// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        /// </summary>
         [Input("publish")]
         public Input<bool>? Publish { get; set; }
 
+        /// <summary>
+        /// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        /// </summary>
         [Input("role")]
         public Input<string>? Role { get; set; }
 
+        /// <summary>
+        /// The Function Compute Service ID.
+        /// </summary>
         [Input("serviceId")]
         public Input<string>? ServiceId { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;
+
+        /// <summary>
+        /// Map for tagging resources.
+        /// </summary>
         public InputMap<string> Tags
         {
             get => _tags ?? (_tags = new InputMap<string>());
             set => _tags = value;
         }
 
+        /// <summary>
+        /// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        /// </summary>
         [Input("tracingConfig")]
         public Input<Inputs.ServiceTracingConfigGetArgs>? TracingConfig { get; set; }
 
+        /// <summary>
+        /// The latest published version of your Function Compute Service.
+        /// </summary>
         [Input("version")]
         public Input<string>? Version { get; set; }
 
+        /// <summary>
+        /// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+        /// </summary>
         [Input("vpcConfig")]
         public Input<Inputs.ServiceVpcConfigGetArgs>? VpcConfig { get; set; }
 

--- a/sdk/dotnet/FC/V2Function.cs
+++ b/sdk/dotnet/FC/V2Function.cs
@@ -9,84 +9,183 @@ using Pulumi.Serialization;
 
 namespace Pulumi.AliCloud.FC
 {
+    /// <summary>
+    /// Provides a FCV2 Function resource. Function is the unit of system scheduling and operation. Functions must be subordinate to services. All functions under the same service share some identical settings, such as service authorization and log configuration.
+    /// 
+    /// For information about FCV2 Function and how to use it, see [What is Function](https://www.alibabacloud.com/help/en/resource-orchestration-service/latest/aliyun-fc-function).
+    /// 
+    /// &gt; **NOTE:** Available since v1.208.0.
+    /// 
+    /// ## Import
+    /// 
+    /// FCV2 Function can be imported using the id, e.g.
+    /// 
+    /// ```sh
+    /// $ pulumi import alicloud:fc/v2Function:V2Function example &lt;service_name&gt;:&lt;function_name&gt;
+    /// ```
+    /// </summary>
     [AliCloudResourceType("alicloud:fc/v2Function:V2Function")]
     public partial class V2Function : global::Pulumi.CustomResource
     {
+        /// <summary>
+        /// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        /// </summary>
         [Output("caPort")]
         public Output<int> CaPort { get; private set; } = null!;
 
+        /// <summary>
+        /// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        /// </summary>
         [Output("code")]
         public Output<Outputs.V2FunctionCode?> Code { get; private set; } = null!;
 
+        /// <summary>
+        /// crc64 of function code.
+        /// </summary>
         [Output("codeChecksum")]
         public Output<string> CodeChecksum { get; private set; } = null!;
 
+        /// <summary>
+        /// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        /// </summary>
         [Output("cpu")]
         public Output<double?> Cpu { get; private set; } = null!;
 
+        /// <summary>
+        /// create time of function.
+        /// </summary>
         [Output("createTime")]
         public Output<string> CreateTime { get; private set; } = null!;
 
+        /// <summary>
+        /// Custom-container runtime related function configuration. See `custom_container_config` below.
+        /// </summary>
         [Output("customContainerConfig")]
         public Output<Outputs.V2FunctionCustomContainerConfig?> CustomContainerConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// Function custom DNS configuration. See `custom_dns` below.
+        /// </summary>
         [Output("customDns")]
         public Output<Outputs.V2FunctionCustomDns?> CustomDns { get; private set; } = null!;
 
+        /// <summary>
+        /// Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        /// </summary>
         [Output("customHealthCheckConfig")]
         public Output<Outputs.V2FunctionCustomHealthCheckConfig?> CustomHealthCheckConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        /// </summary>
         [Output("customRuntimeConfig")]
         public Output<Outputs.V2FunctionCustomRuntimeConfig?> CustomRuntimeConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// description of function.
+        /// </summary>
         [Output("description")]
         public Output<string?> Description { get; private set; } = null!;
 
+        /// <summary>
+        /// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        /// </summary>
         [Output("diskSize")]
         public Output<int?> DiskSize { get; private set; } = null!;
 
+        /// <summary>
+        /// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        /// </summary>
         [Output("environmentVariables")]
         public Output<ImmutableDictionary<string, string>?> EnvironmentVariables { get; private set; } = null!;
 
+        /// <summary>
+        /// The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+        /// </summary>
         [Output("functionArn")]
         public Output<string> FunctionArn { get; private set; } = null!;
 
+        /// <summary>
+        /// function name.
+        /// </summary>
         [Output("functionName")]
         public Output<string> FunctionName { get; private set; } = null!;
 
+        /// <summary>
+        /// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        /// </summary>
         [Output("gpuMemorySize")]
         public Output<int?> GpuMemorySize { get; private set; } = null!;
 
+        /// <summary>
+        /// entry point of function.
+        /// </summary>
         [Output("handler")]
         public Output<string> Handler { get; private set; } = null!;
 
+        /// <summary>
+        /// max running time of initializer.
+        /// </summary>
         [Output("initializationTimeout")]
         public Output<int> InitializationTimeout { get; private set; } = null!;
 
+        /// <summary>
+        /// initializer entry point of function.
+        /// </summary>
         [Output("initializer")]
         public Output<string?> Initializer { get; private set; } = null!;
 
+        /// <summary>
+        /// The maximum concurrency allowed for a single function instance.
+        /// </summary>
         [Output("instanceConcurrency")]
         public Output<int> InstanceConcurrency { get; private set; } = null!;
 
+        /// <summary>
+        /// Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        /// </summary>
         [Output("instanceLifecycleConfig")]
         public Output<Outputs.V2FunctionInstanceLifecycleConfig?> InstanceLifecycleConfig { get; private set; } = null!;
 
+        /// <summary>
+        /// The instance type of the function. Valid values:
+        /// - **e1**: Elastic instance.
+        /// - **c1**: performance instance.
+        /// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+        /// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+        /// - **g1**: Same as **fc.gpu.tesla.1**.
+        /// </summary>
         [Output("instanceType")]
         public Output<string> InstanceType { get; private set; } = null!;
 
+        /// <summary>
+        /// List of layers.
+        /// &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        /// </summary>
         [Output("layers")]
         public Output<ImmutableArray<string>> Layers { get; private set; } = null!;
 
+        /// <summary>
+        /// memory size needed by function.
+        /// </summary>
         [Output("memorySize")]
         public Output<int> MemorySize { get; private set; } = null!;
 
+        /// <summary>
+        /// runtime of function code.
+        /// </summary>
         [Output("runtime")]
         public Output<string> Runtime { get; private set; } = null!;
 
+        /// <summary>
+        /// The name of the function Service.
+        /// </summary>
         [Output("serviceName")]
         public Output<string> ServiceName { get; private set; } = null!;
 
+        /// <summary>
+        /// max running time of function.
+        /// </summary>
         [Output("timeout")]
         public Output<int> Timeout { get; private set; } = null!;
 
@@ -136,85 +235,165 @@ namespace Pulumi.AliCloud.FC
 
     public sealed class V2FunctionArgs : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        /// </summary>
         [Input("caPort")]
         public Input<int>? CaPort { get; set; }
 
+        /// <summary>
+        /// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        /// </summary>
         [Input("code")]
         public Input<Inputs.V2FunctionCodeArgs>? Code { get; set; }
 
+        /// <summary>
+        /// crc64 of function code.
+        /// </summary>
         [Input("codeChecksum")]
         public Input<string>? CodeChecksum { get; set; }
 
+        /// <summary>
+        /// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        /// </summary>
         [Input("cpu")]
         public Input<double>? Cpu { get; set; }
 
+        /// <summary>
+        /// Custom-container runtime related function configuration. See `custom_container_config` below.
+        /// </summary>
         [Input("customContainerConfig")]
         public Input<Inputs.V2FunctionCustomContainerConfigArgs>? CustomContainerConfig { get; set; }
 
+        /// <summary>
+        /// Function custom DNS configuration. See `custom_dns` below.
+        /// </summary>
         [Input("customDns")]
         public Input<Inputs.V2FunctionCustomDnsArgs>? CustomDns { get; set; }
 
+        /// <summary>
+        /// Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        /// </summary>
         [Input("customHealthCheckConfig")]
         public Input<Inputs.V2FunctionCustomHealthCheckConfigArgs>? CustomHealthCheckConfig { get; set; }
 
+        /// <summary>
+        /// Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        /// </summary>
         [Input("customRuntimeConfig")]
         public Input<Inputs.V2FunctionCustomRuntimeConfigArgs>? CustomRuntimeConfig { get; set; }
 
+        /// <summary>
+        /// description of function.
+        /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
 
+        /// <summary>
+        /// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        /// </summary>
         [Input("diskSize")]
         public Input<int>? DiskSize { get; set; }
 
         [Input("environmentVariables")]
         private InputMap<string>? _environmentVariables;
+
+        /// <summary>
+        /// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        /// </summary>
         public InputMap<string> EnvironmentVariables
         {
             get => _environmentVariables ?? (_environmentVariables = new InputMap<string>());
             set => _environmentVariables = value;
         }
 
+        /// <summary>
+        /// function name.
+        /// </summary>
         [Input("functionName", required: true)]
         public Input<string> FunctionName { get; set; } = null!;
 
+        /// <summary>
+        /// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        /// </summary>
         [Input("gpuMemorySize")]
         public Input<int>? GpuMemorySize { get; set; }
 
+        /// <summary>
+        /// entry point of function.
+        /// </summary>
         [Input("handler", required: true)]
         public Input<string> Handler { get; set; } = null!;
 
+        /// <summary>
+        /// max running time of initializer.
+        /// </summary>
         [Input("initializationTimeout")]
         public Input<int>? InitializationTimeout { get; set; }
 
+        /// <summary>
+        /// initializer entry point of function.
+        /// </summary>
         [Input("initializer")]
         public Input<string>? Initializer { get; set; }
 
+        /// <summary>
+        /// The maximum concurrency allowed for a single function instance.
+        /// </summary>
         [Input("instanceConcurrency")]
         public Input<int>? InstanceConcurrency { get; set; }
 
+        /// <summary>
+        /// Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        /// </summary>
         [Input("instanceLifecycleConfig")]
         public Input<Inputs.V2FunctionInstanceLifecycleConfigArgs>? InstanceLifecycleConfig { get; set; }
 
+        /// <summary>
+        /// The instance type of the function. Valid values:
+        /// - **e1**: Elastic instance.
+        /// - **c1**: performance instance.
+        /// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+        /// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+        /// - **g1**: Same as **fc.gpu.tesla.1**.
+        /// </summary>
         [Input("instanceType")]
         public Input<string>? InstanceType { get; set; }
 
         [Input("layers")]
         private InputList<string>? _layers;
+
+        /// <summary>
+        /// List of layers.
+        /// &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        /// </summary>
         public InputList<string> Layers
         {
             get => _layers ?? (_layers = new InputList<string>());
             set => _layers = value;
         }
 
+        /// <summary>
+        /// memory size needed by function.
+        /// </summary>
         [Input("memorySize")]
         public Input<int>? MemorySize { get; set; }
 
+        /// <summary>
+        /// runtime of function code.
+        /// </summary>
         [Input("runtime", required: true)]
         public Input<string> Runtime { get; set; } = null!;
 
+        /// <summary>
+        /// The name of the function Service.
+        /// </summary>
         [Input("serviceName", required: true)]
         public Input<string> ServiceName { get; set; } = null!;
 
+        /// <summary>
+        /// max running time of function.
+        /// </summary>
         [Input("timeout")]
         public Input<int>? Timeout { get; set; }
 
@@ -226,91 +405,177 @@ namespace Pulumi.AliCloud.FC
 
     public sealed class V2FunctionState : global::Pulumi.ResourceArgs
     {
+        /// <summary>
+        /// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        /// </summary>
         [Input("caPort")]
         public Input<int>? CaPort { get; set; }
 
+        /// <summary>
+        /// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        /// </summary>
         [Input("code")]
         public Input<Inputs.V2FunctionCodeGetArgs>? Code { get; set; }
 
+        /// <summary>
+        /// crc64 of function code.
+        /// </summary>
         [Input("codeChecksum")]
         public Input<string>? CodeChecksum { get; set; }
 
+        /// <summary>
+        /// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        /// </summary>
         [Input("cpu")]
         public Input<double>? Cpu { get; set; }
 
+        /// <summary>
+        /// create time of function.
+        /// </summary>
         [Input("createTime")]
         public Input<string>? CreateTime { get; set; }
 
+        /// <summary>
+        /// Custom-container runtime related function configuration. See `custom_container_config` below.
+        /// </summary>
         [Input("customContainerConfig")]
         public Input<Inputs.V2FunctionCustomContainerConfigGetArgs>? CustomContainerConfig { get; set; }
 
+        /// <summary>
+        /// Function custom DNS configuration. See `custom_dns` below.
+        /// </summary>
         [Input("customDns")]
         public Input<Inputs.V2FunctionCustomDnsGetArgs>? CustomDns { get; set; }
 
+        /// <summary>
+        /// Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        /// </summary>
         [Input("customHealthCheckConfig")]
         public Input<Inputs.V2FunctionCustomHealthCheckConfigGetArgs>? CustomHealthCheckConfig { get; set; }
 
+        /// <summary>
+        /// Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        /// </summary>
         [Input("customRuntimeConfig")]
         public Input<Inputs.V2FunctionCustomRuntimeConfigGetArgs>? CustomRuntimeConfig { get; set; }
 
+        /// <summary>
+        /// description of function.
+        /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
 
+        /// <summary>
+        /// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        /// </summary>
         [Input("diskSize")]
         public Input<int>? DiskSize { get; set; }
 
         [Input("environmentVariables")]
         private InputMap<string>? _environmentVariables;
+
+        /// <summary>
+        /// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        /// </summary>
         public InputMap<string> EnvironmentVariables
         {
             get => _environmentVariables ?? (_environmentVariables = new InputMap<string>());
             set => _environmentVariables = value;
         }
 
+        /// <summary>
+        /// The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+        /// </summary>
         [Input("functionArn")]
         public Input<string>? FunctionArn { get; set; }
 
+        /// <summary>
+        /// function name.
+        /// </summary>
         [Input("functionName")]
         public Input<string>? FunctionName { get; set; }
 
+        /// <summary>
+        /// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        /// </summary>
         [Input("gpuMemorySize")]
         public Input<int>? GpuMemorySize { get; set; }
 
+        /// <summary>
+        /// entry point of function.
+        /// </summary>
         [Input("handler")]
         public Input<string>? Handler { get; set; }
 
+        /// <summary>
+        /// max running time of initializer.
+        /// </summary>
         [Input("initializationTimeout")]
         public Input<int>? InitializationTimeout { get; set; }
 
+        /// <summary>
+        /// initializer entry point of function.
+        /// </summary>
         [Input("initializer")]
         public Input<string>? Initializer { get; set; }
 
+        /// <summary>
+        /// The maximum concurrency allowed for a single function instance.
+        /// </summary>
         [Input("instanceConcurrency")]
         public Input<int>? InstanceConcurrency { get; set; }
 
+        /// <summary>
+        /// Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        /// </summary>
         [Input("instanceLifecycleConfig")]
         public Input<Inputs.V2FunctionInstanceLifecycleConfigGetArgs>? InstanceLifecycleConfig { get; set; }
 
+        /// <summary>
+        /// The instance type of the function. Valid values:
+        /// - **e1**: Elastic instance.
+        /// - **c1**: performance instance.
+        /// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+        /// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+        /// - **g1**: Same as **fc.gpu.tesla.1**.
+        /// </summary>
         [Input("instanceType")]
         public Input<string>? InstanceType { get; set; }
 
         [Input("layers")]
         private InputList<string>? _layers;
+
+        /// <summary>
+        /// List of layers.
+        /// &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        /// </summary>
         public InputList<string> Layers
         {
             get => _layers ?? (_layers = new InputList<string>());
             set => _layers = value;
         }
 
+        /// <summary>
+        /// memory size needed by function.
+        /// </summary>
         [Input("memorySize")]
         public Input<int>? MemorySize { get; set; }
 
+        /// <summary>
+        /// runtime of function code.
+        /// </summary>
         [Input("runtime")]
         public Input<string>? Runtime { get; set; }
 
+        /// <summary>
+        /// The name of the function Service.
+        /// </summary>
         [Input("serviceName")]
         public Input<string>? ServiceName { get; set; }
 
+        /// <summary>
+        /// max running time of function.
+        /// </summary>
         [Input("timeout")]
         public Input<int>? Timeout { get; set; }
 

--- a/sdk/go/alicloud/fc/getService.go
+++ b/sdk/go/alicloud/fc/getService.go
@@ -16,32 +16,6 @@ import (
 // For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
 //
 // > **NOTE:** Available since v1.112.0+
-//
-// ## Example Usage
-//
-// ```go
-// package main
-//
-// import (
-//
-//	"github.com/pulumi/pulumi-alicloud/sdk/v3/go/alicloud/fc"
-//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-//
-// )
-//
-//	func main() {
-//		pulumi.Run(func(ctx *pulumi.Context) error {
-//			_, err := fc.LookupService(ctx, &fc.LookupServiceArgs{
-//				Enable: pulumi.StringRef("On"),
-//			}, nil)
-//			if err != nil {
-//				return err
-//			}
-//			return nil
-//		})
-//	}
-//
-// ```
 func LookupService(ctx *pulumi.Context, args *LookupServiceArgs, opts ...pulumi.InvokeOption) (*LookupServiceResult, error) {
 	opts = internal.PkgInvokeDefaultOpts(opts)
 	var rv LookupServiceResult

--- a/sdk/go/alicloud/fc/pulumiTypes.go
+++ b/sdk/go/alicloud/fc/pulumiTypes.go
@@ -1543,7 +1543,7 @@ func (o ServiceNasConfigMountPointArrayOutput) Index(i pulumi.IntInput) ServiceN
 }
 
 type ServiceTracingConfig struct {
-	// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+	// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
 	Params map[string]string `pulumi:"params"`
 	// Tracing protocol type. Currently, only Jaeger is supported.
 	Type string `pulumi:"type"`
@@ -1561,7 +1561,7 @@ type ServiceTracingConfigInput interface {
 }
 
 type ServiceTracingConfigArgs struct {
-	// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+	// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
 	Params pulumi.StringMapInput `pulumi:"params"`
 	// Tracing protocol type. Currently, only Jaeger is supported.
 	Type pulumi.StringInput `pulumi:"type"`
@@ -1644,7 +1644,7 @@ func (o ServiceTracingConfigOutput) ToServiceTracingConfigPtrOutputWithContext(c
 	}).(ServiceTracingConfigPtrOutput)
 }
 
-// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
 func (o ServiceTracingConfigOutput) Params() pulumi.StringMapOutput {
 	return o.ApplyT(func(v ServiceTracingConfig) map[string]string { return v.Params }).(pulumi.StringMapOutput)
 }
@@ -1678,7 +1678,7 @@ func (o ServiceTracingConfigPtrOutput) Elem() ServiceTracingConfigOutput {
 	}).(ServiceTracingConfigOutput)
 }
 
-// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+// Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
 func (o ServiceTracingConfigPtrOutput) Params() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *ServiceTracingConfig) map[string]string {
 		if v == nil {

--- a/sdk/go/alicloud/fc/service.go
+++ b/sdk/go/alicloud/fc/service.go
@@ -11,23 +11,60 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// Provides a Alicloud Function Compute Service resource. The resource is the base of launching Function and Trigger configuration.
+// For information about Service and how to use it, see [What is Function Compute](https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-createservice).
+//
+// > **NOTE:** The resource requires a provider field 'account_id'. See account_id.
+//
+// > **NOTE:** If you happen the error "Argument 'internetAccess' is not supported", you need to log on web console and click button "Apply VPC Function"
+// which is in the upper of [Function Service Web Console](https://fc.console.aliyun.com/) page.
+//
+// > **NOTE:** Currently not all regions support Function Compute Service.
+// For more details supported regions, see [Service endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm)
+//
+// > **NOTE:** Available since v1.93.0.
+// ## Module Support
+//
+// You can use to the existing fc module to create a service and a function quickly and then set several triggers for it.
+//
+// ## Import
+//
+// Function Compute Service can be imported using the id or name, e.g.
+//
+// ```sh
+// $ pulumi import alicloud:fc/service:Service foo my-fc-service
+// ```
 type Service struct {
 	pulumi.CustomResourceState
 
-	Description    pulumi.StringPtrOutput        `pulumi:"description"`
-	InternetAccess pulumi.BoolPtrOutput          `pulumi:"internetAccess"`
-	LastModified   pulumi.StringOutput           `pulumi:"lastModified"`
-	LogConfig      ServiceLogConfigPtrOutput     `pulumi:"logConfig"`
-	Name           pulumi.StringOutput           `pulumi:"name"`
-	NamePrefix     pulumi.StringPtrOutput        `pulumi:"namePrefix"`
-	NasConfig      ServiceNasConfigPtrOutput     `pulumi:"nasConfig"`
-	Publish        pulumi.BoolPtrOutput          `pulumi:"publish"`
-	Role           pulumi.StringPtrOutput        `pulumi:"role"`
-	ServiceId      pulumi.StringOutput           `pulumi:"serviceId"`
-	Tags           pulumi.StringMapOutput        `pulumi:"tags"`
-	TracingConfig  ServiceTracingConfigPtrOutput `pulumi:"tracingConfig"`
-	Version        pulumi.StringOutput           `pulumi:"version"`
-	VpcConfig      ServiceVpcConfigPtrOutput     `pulumi:"vpcConfig"`
+	// The Function Compute Service description.
+	Description pulumi.StringPtrOutput `pulumi:"description"`
+	// Whether to allow the Service to access Internet. Default to "true".
+	InternetAccess pulumi.BoolPtrOutput `pulumi:"internetAccess"`
+	// The date this resource was last modified.
+	LastModified pulumi.StringOutput `pulumi:"lastModified"`
+	// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+	LogConfig ServiceLogConfigPtrOutput `pulumi:"logConfig"`
+	// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+	Name pulumi.StringOutput `pulumi:"name"`
+	// Setting a prefix to get a only name. It is conflict with `name`.
+	NamePrefix pulumi.StringPtrOutput `pulumi:"namePrefix"`
+	// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+	NasConfig ServiceNasConfigPtrOutput `pulumi:"nasConfig"`
+	// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+	Publish pulumi.BoolPtrOutput `pulumi:"publish"`
+	// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+	Role pulumi.StringPtrOutput `pulumi:"role"`
+	// The Function Compute Service ID.
+	ServiceId pulumi.StringOutput `pulumi:"serviceId"`
+	// Map for tagging resources.
+	Tags pulumi.StringMapOutput `pulumi:"tags"`
+	// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+	TracingConfig ServiceTracingConfigPtrOutput `pulumi:"tracingConfig"`
+	// The latest published version of your Function Compute Service.
+	Version pulumi.StringOutput `pulumi:"version"`
+	// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+	VpcConfig ServiceVpcConfigPtrOutput `pulumi:"vpcConfig"`
 }
 
 // NewService registers a new resource with the given unique name, arguments, and options.
@@ -60,37 +97,65 @@ func GetService(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering Service resources.
 type serviceState struct {
-	Description    *string               `pulumi:"description"`
-	InternetAccess *bool                 `pulumi:"internetAccess"`
-	LastModified   *string               `pulumi:"lastModified"`
-	LogConfig      *ServiceLogConfig     `pulumi:"logConfig"`
-	Name           *string               `pulumi:"name"`
-	NamePrefix     *string               `pulumi:"namePrefix"`
-	NasConfig      *ServiceNasConfig     `pulumi:"nasConfig"`
-	Publish        *bool                 `pulumi:"publish"`
-	Role           *string               `pulumi:"role"`
-	ServiceId      *string               `pulumi:"serviceId"`
-	Tags           map[string]string     `pulumi:"tags"`
-	TracingConfig  *ServiceTracingConfig `pulumi:"tracingConfig"`
-	Version        *string               `pulumi:"version"`
-	VpcConfig      *ServiceVpcConfig     `pulumi:"vpcConfig"`
+	// The Function Compute Service description.
+	Description *string `pulumi:"description"`
+	// Whether to allow the Service to access Internet. Default to "true".
+	InternetAccess *bool `pulumi:"internetAccess"`
+	// The date this resource was last modified.
+	LastModified *string `pulumi:"lastModified"`
+	// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+	LogConfig *ServiceLogConfig `pulumi:"logConfig"`
+	// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+	Name *string `pulumi:"name"`
+	// Setting a prefix to get a only name. It is conflict with `name`.
+	NamePrefix *string `pulumi:"namePrefix"`
+	// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+	NasConfig *ServiceNasConfig `pulumi:"nasConfig"`
+	// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+	Publish *bool `pulumi:"publish"`
+	// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+	Role *string `pulumi:"role"`
+	// The Function Compute Service ID.
+	ServiceId *string `pulumi:"serviceId"`
+	// Map for tagging resources.
+	Tags map[string]string `pulumi:"tags"`
+	// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+	TracingConfig *ServiceTracingConfig `pulumi:"tracingConfig"`
+	// The latest published version of your Function Compute Service.
+	Version *string `pulumi:"version"`
+	// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+	VpcConfig *ServiceVpcConfig `pulumi:"vpcConfig"`
 }
 
 type ServiceState struct {
-	Description    pulumi.StringPtrInput
+	// The Function Compute Service description.
+	Description pulumi.StringPtrInput
+	// Whether to allow the Service to access Internet. Default to "true".
 	InternetAccess pulumi.BoolPtrInput
-	LastModified   pulumi.StringPtrInput
-	LogConfig      ServiceLogConfigPtrInput
-	Name           pulumi.StringPtrInput
-	NamePrefix     pulumi.StringPtrInput
-	NasConfig      ServiceNasConfigPtrInput
-	Publish        pulumi.BoolPtrInput
-	Role           pulumi.StringPtrInput
-	ServiceId      pulumi.StringPtrInput
-	Tags           pulumi.StringMapInput
-	TracingConfig  ServiceTracingConfigPtrInput
-	Version        pulumi.StringPtrInput
-	VpcConfig      ServiceVpcConfigPtrInput
+	// The date this resource was last modified.
+	LastModified pulumi.StringPtrInput
+	// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+	LogConfig ServiceLogConfigPtrInput
+	// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+	Name pulumi.StringPtrInput
+	// Setting a prefix to get a only name. It is conflict with `name`.
+	NamePrefix pulumi.StringPtrInput
+	// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+	NasConfig ServiceNasConfigPtrInput
+	// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+	Publish pulumi.BoolPtrInput
+	// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+	Role pulumi.StringPtrInput
+	// The Function Compute Service ID.
+	ServiceId pulumi.StringPtrInput
+	// Map for tagging resources.
+	Tags pulumi.StringMapInput
+	// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+	TracingConfig ServiceTracingConfigPtrInput
+	// The latest published version of your Function Compute Service.
+	Version pulumi.StringPtrInput
+	// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+	VpcConfig ServiceVpcConfigPtrInput
 }
 
 func (ServiceState) ElementType() reflect.Type {
@@ -98,32 +163,54 @@ func (ServiceState) ElementType() reflect.Type {
 }
 
 type serviceArgs struct {
-	Description    *string               `pulumi:"description"`
-	InternetAccess *bool                 `pulumi:"internetAccess"`
-	LogConfig      *ServiceLogConfig     `pulumi:"logConfig"`
-	Name           *string               `pulumi:"name"`
-	NamePrefix     *string               `pulumi:"namePrefix"`
-	NasConfig      *ServiceNasConfig     `pulumi:"nasConfig"`
-	Publish        *bool                 `pulumi:"publish"`
-	Role           *string               `pulumi:"role"`
-	Tags           map[string]string     `pulumi:"tags"`
-	TracingConfig  *ServiceTracingConfig `pulumi:"tracingConfig"`
-	VpcConfig      *ServiceVpcConfig     `pulumi:"vpcConfig"`
+	// The Function Compute Service description.
+	Description *string `pulumi:"description"`
+	// Whether to allow the Service to access Internet. Default to "true".
+	InternetAccess *bool `pulumi:"internetAccess"`
+	// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+	LogConfig *ServiceLogConfig `pulumi:"logConfig"`
+	// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+	Name *string `pulumi:"name"`
+	// Setting a prefix to get a only name. It is conflict with `name`.
+	NamePrefix *string `pulumi:"namePrefix"`
+	// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+	NasConfig *ServiceNasConfig `pulumi:"nasConfig"`
+	// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+	Publish *bool `pulumi:"publish"`
+	// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+	Role *string `pulumi:"role"`
+	// Map for tagging resources.
+	Tags map[string]string `pulumi:"tags"`
+	// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+	TracingConfig *ServiceTracingConfig `pulumi:"tracingConfig"`
+	// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+	VpcConfig *ServiceVpcConfig `pulumi:"vpcConfig"`
 }
 
 // The set of arguments for constructing a Service resource.
 type ServiceArgs struct {
-	Description    pulumi.StringPtrInput
+	// The Function Compute Service description.
+	Description pulumi.StringPtrInput
+	// Whether to allow the Service to access Internet. Default to "true".
 	InternetAccess pulumi.BoolPtrInput
-	LogConfig      ServiceLogConfigPtrInput
-	Name           pulumi.StringPtrInput
-	NamePrefix     pulumi.StringPtrInput
-	NasConfig      ServiceNasConfigPtrInput
-	Publish        pulumi.BoolPtrInput
-	Role           pulumi.StringPtrInput
-	Tags           pulumi.StringMapInput
-	TracingConfig  ServiceTracingConfigPtrInput
-	VpcConfig      ServiceVpcConfigPtrInput
+	// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+	LogConfig ServiceLogConfigPtrInput
+	// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+	Name pulumi.StringPtrInput
+	// Setting a prefix to get a only name. It is conflict with `name`.
+	NamePrefix pulumi.StringPtrInput
+	// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+	NasConfig ServiceNasConfigPtrInput
+	// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+	Publish pulumi.BoolPtrInput
+	// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+	Role pulumi.StringPtrInput
+	// Map for tagging resources.
+	Tags pulumi.StringMapInput
+	// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+	TracingConfig ServiceTracingConfigPtrInput
+	// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+	VpcConfig ServiceVpcConfigPtrInput
 }
 
 func (ServiceArgs) ElementType() reflect.Type {
@@ -213,58 +300,72 @@ func (o ServiceOutput) ToServiceOutputWithContext(ctx context.Context) ServiceOu
 	return o
 }
 
+// The Function Compute Service description.
 func (o ServiceOutput) Description() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringPtrOutput { return v.Description }).(pulumi.StringPtrOutput)
 }
 
+// Whether to allow the Service to access Internet. Default to "true".
 func (o ServiceOutput) InternetAccess() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Service) pulumi.BoolPtrOutput { return v.InternetAccess }).(pulumi.BoolPtrOutput)
 }
 
+// The date this resource was last modified.
 func (o ServiceOutput) LastModified() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.LastModified }).(pulumi.StringOutput)
 }
 
+// Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
 func (o ServiceOutput) LogConfig() ServiceLogConfigPtrOutput {
 	return o.ApplyT(func(v *Service) ServiceLogConfigPtrOutput { return v.LogConfig }).(ServiceLogConfigPtrOutput)
 }
 
+// The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
 func (o ServiceOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.Name }).(pulumi.StringOutput)
 }
 
+// Setting a prefix to get a only name. It is conflict with `name`.
 func (o ServiceOutput) NamePrefix() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringPtrOutput { return v.NamePrefix }).(pulumi.StringPtrOutput)
 }
 
+// Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
 func (o ServiceOutput) NasConfig() ServiceNasConfigPtrOutput {
 	return o.ApplyT(func(v *Service) ServiceNasConfigPtrOutput { return v.NasConfig }).(ServiceNasConfigPtrOutput)
 }
 
+// Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
 func (o ServiceOutput) Publish() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Service) pulumi.BoolPtrOutput { return v.Publish }).(pulumi.BoolPtrOutput)
 }
 
+// RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
 func (o ServiceOutput) Role() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringPtrOutput { return v.Role }).(pulumi.StringPtrOutput)
 }
 
+// The Function Compute Service ID.
 func (o ServiceOutput) ServiceId() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.ServiceId }).(pulumi.StringOutput)
 }
 
+// Map for tagging resources.
 func (o ServiceOutput) Tags() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringMapOutput { return v.Tags }).(pulumi.StringMapOutput)
 }
 
+// Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
 func (o ServiceOutput) TracingConfig() ServiceTracingConfigPtrOutput {
 	return o.ApplyT(func(v *Service) ServiceTracingConfigPtrOutput { return v.TracingConfig }).(ServiceTracingConfigPtrOutput)
 }
 
+// The latest published version of your Function Compute Service.
 func (o ServiceOutput) Version() pulumi.StringOutput {
 	return o.ApplyT(func(v *Service) pulumi.StringOutput { return v.Version }).(pulumi.StringOutput)
 }
 
+// Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
 func (o ServiceOutput) VpcConfig() ServiceVpcConfigPtrOutput {
 	return o.ApplyT(func(v *Service) ServiceVpcConfigPtrOutput { return v.VpcConfig }).(ServiceVpcConfigPtrOutput)
 }

--- a/sdk/go/alicloud/fc/v2function.go
+++ b/sdk/go/alicloud/fc/v2function.go
@@ -12,35 +12,80 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// Provides a FCV2 Function resource. Function is the unit of system scheduling and operation. Functions must be subordinate to services. All functions under the same service share some identical settings, such as service authorization and log configuration.
+//
+// For information about FCV2 Function and how to use it, see [What is Function](https://www.alibabacloud.com/help/en/resource-orchestration-service/latest/aliyun-fc-function).
+//
+// > **NOTE:** Available since v1.208.0.
+//
+// ## Import
+//
+// FCV2 Function can be imported using the id, e.g.
+//
+// ```sh
+// $ pulumi import alicloud:fc/v2Function:V2Function example <service_name>:<function_name>
+// ```
 type V2Function struct {
 	pulumi.CustomResourceState
 
-	CaPort                  pulumi.IntOutput                           `pulumi:"caPort"`
-	Code                    V2FunctionCodePtrOutput                    `pulumi:"code"`
-	CodeChecksum            pulumi.StringOutput                        `pulumi:"codeChecksum"`
-	Cpu                     pulumi.Float64PtrOutput                    `pulumi:"cpu"`
-	CreateTime              pulumi.StringOutput                        `pulumi:"createTime"`
-	CustomContainerConfig   V2FunctionCustomContainerConfigPtrOutput   `pulumi:"customContainerConfig"`
-	CustomDns               V2FunctionCustomDnsPtrOutput               `pulumi:"customDns"`
+	// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+	CaPort pulumi.IntOutput `pulumi:"caPort"`
+	// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+	Code V2FunctionCodePtrOutput `pulumi:"code"`
+	// crc64 of function code.
+	CodeChecksum pulumi.StringOutput `pulumi:"codeChecksum"`
+	// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+	Cpu pulumi.Float64PtrOutput `pulumi:"cpu"`
+	// create time of function.
+	CreateTime pulumi.StringOutput `pulumi:"createTime"`
+	// Custom-container runtime related function configuration. See `customContainerConfig` below.
+	CustomContainerConfig V2FunctionCustomContainerConfigPtrOutput `pulumi:"customContainerConfig"`
+	// Function custom DNS configuration. See `customDns` below.
+	CustomDns V2FunctionCustomDnsPtrOutput `pulumi:"customDns"`
+	// Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
 	CustomHealthCheckConfig V2FunctionCustomHealthCheckConfigPtrOutput `pulumi:"customHealthCheckConfig"`
-	CustomRuntimeConfig     V2FunctionCustomRuntimeConfigPtrOutput     `pulumi:"customRuntimeConfig"`
-	Description             pulumi.StringPtrOutput                     `pulumi:"description"`
-	DiskSize                pulumi.IntPtrOutput                        `pulumi:"diskSize"`
-	EnvironmentVariables    pulumi.StringMapOutput                     `pulumi:"environmentVariables"`
-	FunctionArn             pulumi.StringOutput                        `pulumi:"functionArn"`
-	FunctionName            pulumi.StringOutput                        `pulumi:"functionName"`
-	GpuMemorySize           pulumi.IntPtrOutput                        `pulumi:"gpuMemorySize"`
-	Handler                 pulumi.StringOutput                        `pulumi:"handler"`
-	InitializationTimeout   pulumi.IntOutput                           `pulumi:"initializationTimeout"`
-	Initializer             pulumi.StringPtrOutput                     `pulumi:"initializer"`
-	InstanceConcurrency     pulumi.IntOutput                           `pulumi:"instanceConcurrency"`
+	// Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+	CustomRuntimeConfig V2FunctionCustomRuntimeConfigPtrOutput `pulumi:"customRuntimeConfig"`
+	// description of function.
+	Description pulumi.StringPtrOutput `pulumi:"description"`
+	// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+	DiskSize pulumi.IntPtrOutput `pulumi:"diskSize"`
+	// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+	EnvironmentVariables pulumi.StringMapOutput `pulumi:"environmentVariables"`
+	// The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+	FunctionArn pulumi.StringOutput `pulumi:"functionArn"`
+	// function name.
+	FunctionName pulumi.StringOutput `pulumi:"functionName"`
+	// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+	GpuMemorySize pulumi.IntPtrOutput `pulumi:"gpuMemorySize"`
+	// entry point of function.
+	Handler pulumi.StringOutput `pulumi:"handler"`
+	// max running time of initializer.
+	InitializationTimeout pulumi.IntOutput `pulumi:"initializationTimeout"`
+	// initializer entry point of function.
+	Initializer pulumi.StringPtrOutput `pulumi:"initializer"`
+	// The maximum concurrency allowed for a single function instance.
+	InstanceConcurrency pulumi.IntOutput `pulumi:"instanceConcurrency"`
+	// Instance lifecycle configuration. See `instanceLifecycleConfig` below.
 	InstanceLifecycleConfig V2FunctionInstanceLifecycleConfigPtrOutput `pulumi:"instanceLifecycleConfig"`
-	InstanceType            pulumi.StringOutput                        `pulumi:"instanceType"`
-	Layers                  pulumi.StringArrayOutput                   `pulumi:"layers"`
-	MemorySize              pulumi.IntOutput                           `pulumi:"memorySize"`
-	Runtime                 pulumi.StringOutput                        `pulumi:"runtime"`
-	ServiceName             pulumi.StringOutput                        `pulumi:"serviceName"`
-	Timeout                 pulumi.IntOutput                           `pulumi:"timeout"`
+	// The instance type of the function. Valid values:
+	// - **e1**: Elastic instance.
+	// - **c1**: performance instance.
+	// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+	// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+	// - **g1**: Same as **fc.gpu.tesla.1**.
+	InstanceType pulumi.StringOutput `pulumi:"instanceType"`
+	// List of layers.
+	// > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+	Layers pulumi.StringArrayOutput `pulumi:"layers"`
+	// memory size needed by function.
+	MemorySize pulumi.IntOutput `pulumi:"memorySize"`
+	// runtime of function code.
+	Runtime pulumi.StringOutput `pulumi:"runtime"`
+	// The name of the function Service.
+	ServiceName pulumi.StringOutput `pulumi:"serviceName"`
+	// max running time of function.
+	Timeout pulumi.IntOutput `pulumi:"timeout"`
 }
 
 // NewV2Function registers a new resource with the given unique name, arguments, and options.
@@ -85,61 +130,125 @@ func GetV2Function(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering V2Function resources.
 type v2functionState struct {
-	CaPort                  *int                               `pulumi:"caPort"`
-	Code                    *V2FunctionCode                    `pulumi:"code"`
-	CodeChecksum            *string                            `pulumi:"codeChecksum"`
-	Cpu                     *float64                           `pulumi:"cpu"`
-	CreateTime              *string                            `pulumi:"createTime"`
-	CustomContainerConfig   *V2FunctionCustomContainerConfig   `pulumi:"customContainerConfig"`
-	CustomDns               *V2FunctionCustomDns               `pulumi:"customDns"`
+	// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+	CaPort *int `pulumi:"caPort"`
+	// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+	Code *V2FunctionCode `pulumi:"code"`
+	// crc64 of function code.
+	CodeChecksum *string `pulumi:"codeChecksum"`
+	// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+	Cpu *float64 `pulumi:"cpu"`
+	// create time of function.
+	CreateTime *string `pulumi:"createTime"`
+	// Custom-container runtime related function configuration. See `customContainerConfig` below.
+	CustomContainerConfig *V2FunctionCustomContainerConfig `pulumi:"customContainerConfig"`
+	// Function custom DNS configuration. See `customDns` below.
+	CustomDns *V2FunctionCustomDns `pulumi:"customDns"`
+	// Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
 	CustomHealthCheckConfig *V2FunctionCustomHealthCheckConfig `pulumi:"customHealthCheckConfig"`
-	CustomRuntimeConfig     *V2FunctionCustomRuntimeConfig     `pulumi:"customRuntimeConfig"`
-	Description             *string                            `pulumi:"description"`
-	DiskSize                *int                               `pulumi:"diskSize"`
-	EnvironmentVariables    map[string]string                  `pulumi:"environmentVariables"`
-	FunctionArn             *string                            `pulumi:"functionArn"`
-	FunctionName            *string                            `pulumi:"functionName"`
-	GpuMemorySize           *int                               `pulumi:"gpuMemorySize"`
-	Handler                 *string                            `pulumi:"handler"`
-	InitializationTimeout   *int                               `pulumi:"initializationTimeout"`
-	Initializer             *string                            `pulumi:"initializer"`
-	InstanceConcurrency     *int                               `pulumi:"instanceConcurrency"`
+	// Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+	CustomRuntimeConfig *V2FunctionCustomRuntimeConfig `pulumi:"customRuntimeConfig"`
+	// description of function.
+	Description *string `pulumi:"description"`
+	// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+	DiskSize *int `pulumi:"diskSize"`
+	// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+	EnvironmentVariables map[string]string `pulumi:"environmentVariables"`
+	// The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+	FunctionArn *string `pulumi:"functionArn"`
+	// function name.
+	FunctionName *string `pulumi:"functionName"`
+	// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+	GpuMemorySize *int `pulumi:"gpuMemorySize"`
+	// entry point of function.
+	Handler *string `pulumi:"handler"`
+	// max running time of initializer.
+	InitializationTimeout *int `pulumi:"initializationTimeout"`
+	// initializer entry point of function.
+	Initializer *string `pulumi:"initializer"`
+	// The maximum concurrency allowed for a single function instance.
+	InstanceConcurrency *int `pulumi:"instanceConcurrency"`
+	// Instance lifecycle configuration. See `instanceLifecycleConfig` below.
 	InstanceLifecycleConfig *V2FunctionInstanceLifecycleConfig `pulumi:"instanceLifecycleConfig"`
-	InstanceType            *string                            `pulumi:"instanceType"`
-	Layers                  []string                           `pulumi:"layers"`
-	MemorySize              *int                               `pulumi:"memorySize"`
-	Runtime                 *string                            `pulumi:"runtime"`
-	ServiceName             *string                            `pulumi:"serviceName"`
-	Timeout                 *int                               `pulumi:"timeout"`
+	// The instance type of the function. Valid values:
+	// - **e1**: Elastic instance.
+	// - **c1**: performance instance.
+	// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+	// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+	// - **g1**: Same as **fc.gpu.tesla.1**.
+	InstanceType *string `pulumi:"instanceType"`
+	// List of layers.
+	// > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+	Layers []string `pulumi:"layers"`
+	// memory size needed by function.
+	MemorySize *int `pulumi:"memorySize"`
+	// runtime of function code.
+	Runtime *string `pulumi:"runtime"`
+	// The name of the function Service.
+	ServiceName *string `pulumi:"serviceName"`
+	// max running time of function.
+	Timeout *int `pulumi:"timeout"`
 }
 
 type V2FunctionState struct {
-	CaPort                  pulumi.IntPtrInput
-	Code                    V2FunctionCodePtrInput
-	CodeChecksum            pulumi.StringPtrInput
-	Cpu                     pulumi.Float64PtrInput
-	CreateTime              pulumi.StringPtrInput
-	CustomContainerConfig   V2FunctionCustomContainerConfigPtrInput
-	CustomDns               V2FunctionCustomDnsPtrInput
+	// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+	CaPort pulumi.IntPtrInput
+	// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+	Code V2FunctionCodePtrInput
+	// crc64 of function code.
+	CodeChecksum pulumi.StringPtrInput
+	// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+	Cpu pulumi.Float64PtrInput
+	// create time of function.
+	CreateTime pulumi.StringPtrInput
+	// Custom-container runtime related function configuration. See `customContainerConfig` below.
+	CustomContainerConfig V2FunctionCustomContainerConfigPtrInput
+	// Function custom DNS configuration. See `customDns` below.
+	CustomDns V2FunctionCustomDnsPtrInput
+	// Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
 	CustomHealthCheckConfig V2FunctionCustomHealthCheckConfigPtrInput
-	CustomRuntimeConfig     V2FunctionCustomRuntimeConfigPtrInput
-	Description             pulumi.StringPtrInput
-	DiskSize                pulumi.IntPtrInput
-	EnvironmentVariables    pulumi.StringMapInput
-	FunctionArn             pulumi.StringPtrInput
-	FunctionName            pulumi.StringPtrInput
-	GpuMemorySize           pulumi.IntPtrInput
-	Handler                 pulumi.StringPtrInput
-	InitializationTimeout   pulumi.IntPtrInput
-	Initializer             pulumi.StringPtrInput
-	InstanceConcurrency     pulumi.IntPtrInput
+	// Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+	CustomRuntimeConfig V2FunctionCustomRuntimeConfigPtrInput
+	// description of function.
+	Description pulumi.StringPtrInput
+	// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+	DiskSize pulumi.IntPtrInput
+	// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+	EnvironmentVariables pulumi.StringMapInput
+	// The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+	FunctionArn pulumi.StringPtrInput
+	// function name.
+	FunctionName pulumi.StringPtrInput
+	// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+	GpuMemorySize pulumi.IntPtrInput
+	// entry point of function.
+	Handler pulumi.StringPtrInput
+	// max running time of initializer.
+	InitializationTimeout pulumi.IntPtrInput
+	// initializer entry point of function.
+	Initializer pulumi.StringPtrInput
+	// The maximum concurrency allowed for a single function instance.
+	InstanceConcurrency pulumi.IntPtrInput
+	// Instance lifecycle configuration. See `instanceLifecycleConfig` below.
 	InstanceLifecycleConfig V2FunctionInstanceLifecycleConfigPtrInput
-	InstanceType            pulumi.StringPtrInput
-	Layers                  pulumi.StringArrayInput
-	MemorySize              pulumi.IntPtrInput
-	Runtime                 pulumi.StringPtrInput
-	ServiceName             pulumi.StringPtrInput
-	Timeout                 pulumi.IntPtrInput
+	// The instance type of the function. Valid values:
+	// - **e1**: Elastic instance.
+	// - **c1**: performance instance.
+	// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+	// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+	// - **g1**: Same as **fc.gpu.tesla.1**.
+	InstanceType pulumi.StringPtrInput
+	// List of layers.
+	// > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+	Layers pulumi.StringArrayInput
+	// memory size needed by function.
+	MemorySize pulumi.IntPtrInput
+	// runtime of function code.
+	Runtime pulumi.StringPtrInput
+	// The name of the function Service.
+	ServiceName pulumi.StringPtrInput
+	// max running time of function.
+	Timeout pulumi.IntPtrInput
 }
 
 func (V2FunctionState) ElementType() reflect.Type {
@@ -147,58 +256,118 @@ func (V2FunctionState) ElementType() reflect.Type {
 }
 
 type v2functionArgs struct {
-	CaPort                  *int                               `pulumi:"caPort"`
-	Code                    *V2FunctionCode                    `pulumi:"code"`
-	CodeChecksum            *string                            `pulumi:"codeChecksum"`
-	Cpu                     *float64                           `pulumi:"cpu"`
-	CustomContainerConfig   *V2FunctionCustomContainerConfig   `pulumi:"customContainerConfig"`
-	CustomDns               *V2FunctionCustomDns               `pulumi:"customDns"`
+	// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+	CaPort *int `pulumi:"caPort"`
+	// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+	Code *V2FunctionCode `pulumi:"code"`
+	// crc64 of function code.
+	CodeChecksum *string `pulumi:"codeChecksum"`
+	// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+	Cpu *float64 `pulumi:"cpu"`
+	// Custom-container runtime related function configuration. See `customContainerConfig` below.
+	CustomContainerConfig *V2FunctionCustomContainerConfig `pulumi:"customContainerConfig"`
+	// Function custom DNS configuration. See `customDns` below.
+	CustomDns *V2FunctionCustomDns `pulumi:"customDns"`
+	// Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
 	CustomHealthCheckConfig *V2FunctionCustomHealthCheckConfig `pulumi:"customHealthCheckConfig"`
-	CustomRuntimeConfig     *V2FunctionCustomRuntimeConfig     `pulumi:"customRuntimeConfig"`
-	Description             *string                            `pulumi:"description"`
-	DiskSize                *int                               `pulumi:"diskSize"`
-	EnvironmentVariables    map[string]string                  `pulumi:"environmentVariables"`
-	FunctionName            string                             `pulumi:"functionName"`
-	GpuMemorySize           *int                               `pulumi:"gpuMemorySize"`
-	Handler                 string                             `pulumi:"handler"`
-	InitializationTimeout   *int                               `pulumi:"initializationTimeout"`
-	Initializer             *string                            `pulumi:"initializer"`
-	InstanceConcurrency     *int                               `pulumi:"instanceConcurrency"`
+	// Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+	CustomRuntimeConfig *V2FunctionCustomRuntimeConfig `pulumi:"customRuntimeConfig"`
+	// description of function.
+	Description *string `pulumi:"description"`
+	// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+	DiskSize *int `pulumi:"diskSize"`
+	// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+	EnvironmentVariables map[string]string `pulumi:"environmentVariables"`
+	// function name.
+	FunctionName string `pulumi:"functionName"`
+	// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+	GpuMemorySize *int `pulumi:"gpuMemorySize"`
+	// entry point of function.
+	Handler string `pulumi:"handler"`
+	// max running time of initializer.
+	InitializationTimeout *int `pulumi:"initializationTimeout"`
+	// initializer entry point of function.
+	Initializer *string `pulumi:"initializer"`
+	// The maximum concurrency allowed for a single function instance.
+	InstanceConcurrency *int `pulumi:"instanceConcurrency"`
+	// Instance lifecycle configuration. See `instanceLifecycleConfig` below.
 	InstanceLifecycleConfig *V2FunctionInstanceLifecycleConfig `pulumi:"instanceLifecycleConfig"`
-	InstanceType            *string                            `pulumi:"instanceType"`
-	Layers                  []string                           `pulumi:"layers"`
-	MemorySize              *int                               `pulumi:"memorySize"`
-	Runtime                 string                             `pulumi:"runtime"`
-	ServiceName             string                             `pulumi:"serviceName"`
-	Timeout                 *int                               `pulumi:"timeout"`
+	// The instance type of the function. Valid values:
+	// - **e1**: Elastic instance.
+	// - **c1**: performance instance.
+	// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+	// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+	// - **g1**: Same as **fc.gpu.tesla.1**.
+	InstanceType *string `pulumi:"instanceType"`
+	// List of layers.
+	// > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+	Layers []string `pulumi:"layers"`
+	// memory size needed by function.
+	MemorySize *int `pulumi:"memorySize"`
+	// runtime of function code.
+	Runtime string `pulumi:"runtime"`
+	// The name of the function Service.
+	ServiceName string `pulumi:"serviceName"`
+	// max running time of function.
+	Timeout *int `pulumi:"timeout"`
 }
 
 // The set of arguments for constructing a V2Function resource.
 type V2FunctionArgs struct {
-	CaPort                  pulumi.IntPtrInput
-	Code                    V2FunctionCodePtrInput
-	CodeChecksum            pulumi.StringPtrInput
-	Cpu                     pulumi.Float64PtrInput
-	CustomContainerConfig   V2FunctionCustomContainerConfigPtrInput
-	CustomDns               V2FunctionCustomDnsPtrInput
+	// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+	CaPort pulumi.IntPtrInput
+	// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+	Code V2FunctionCodePtrInput
+	// crc64 of function code.
+	CodeChecksum pulumi.StringPtrInput
+	// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+	Cpu pulumi.Float64PtrInput
+	// Custom-container runtime related function configuration. See `customContainerConfig` below.
+	CustomContainerConfig V2FunctionCustomContainerConfigPtrInput
+	// Function custom DNS configuration. See `customDns` below.
+	CustomDns V2FunctionCustomDnsPtrInput
+	// Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
 	CustomHealthCheckConfig V2FunctionCustomHealthCheckConfigPtrInput
-	CustomRuntimeConfig     V2FunctionCustomRuntimeConfigPtrInput
-	Description             pulumi.StringPtrInput
-	DiskSize                pulumi.IntPtrInput
-	EnvironmentVariables    pulumi.StringMapInput
-	FunctionName            pulumi.StringInput
-	GpuMemorySize           pulumi.IntPtrInput
-	Handler                 pulumi.StringInput
-	InitializationTimeout   pulumi.IntPtrInput
-	Initializer             pulumi.StringPtrInput
-	InstanceConcurrency     pulumi.IntPtrInput
+	// Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+	CustomRuntimeConfig V2FunctionCustomRuntimeConfigPtrInput
+	// description of function.
+	Description pulumi.StringPtrInput
+	// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+	DiskSize pulumi.IntPtrInput
+	// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+	EnvironmentVariables pulumi.StringMapInput
+	// function name.
+	FunctionName pulumi.StringInput
+	// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+	GpuMemorySize pulumi.IntPtrInput
+	// entry point of function.
+	Handler pulumi.StringInput
+	// max running time of initializer.
+	InitializationTimeout pulumi.IntPtrInput
+	// initializer entry point of function.
+	Initializer pulumi.StringPtrInput
+	// The maximum concurrency allowed for a single function instance.
+	InstanceConcurrency pulumi.IntPtrInput
+	// Instance lifecycle configuration. See `instanceLifecycleConfig` below.
 	InstanceLifecycleConfig V2FunctionInstanceLifecycleConfigPtrInput
-	InstanceType            pulumi.StringPtrInput
-	Layers                  pulumi.StringArrayInput
-	MemorySize              pulumi.IntPtrInput
-	Runtime                 pulumi.StringInput
-	ServiceName             pulumi.StringInput
-	Timeout                 pulumi.IntPtrInput
+	// The instance type of the function. Valid values:
+	// - **e1**: Elastic instance.
+	// - **c1**: performance instance.
+	// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+	// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+	// - **g1**: Same as **fc.gpu.tesla.1**.
+	InstanceType pulumi.StringPtrInput
+	// List of layers.
+	// > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+	Layers pulumi.StringArrayInput
+	// memory size needed by function.
+	MemorySize pulumi.IntPtrInput
+	// runtime of function code.
+	Runtime pulumi.StringInput
+	// The name of the function Service.
+	ServiceName pulumi.StringInput
+	// max running time of function.
+	Timeout pulumi.IntPtrInput
 }
 
 func (V2FunctionArgs) ElementType() reflect.Type {
@@ -288,106 +457,138 @@ func (o V2FunctionOutput) ToV2FunctionOutputWithContext(ctx context.Context) V2F
 	return o
 }
 
+// The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
 func (o V2FunctionOutput) CaPort() pulumi.IntOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntOutput { return v.CaPort }).(pulumi.IntOutput)
 }
 
+// Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
 func (o V2FunctionOutput) Code() V2FunctionCodePtrOutput {
 	return o.ApplyT(func(v *V2Function) V2FunctionCodePtrOutput { return v.Code }).(V2FunctionCodePtrOutput)
 }
 
+// crc64 of function code.
 func (o V2FunctionOutput) CodeChecksum() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.CodeChecksum }).(pulumi.StringOutput)
 }
 
+// The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
 func (o V2FunctionOutput) Cpu() pulumi.Float64PtrOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.Float64PtrOutput { return v.Cpu }).(pulumi.Float64PtrOutput)
 }
 
+// create time of function.
 func (o V2FunctionOutput) CreateTime() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.CreateTime }).(pulumi.StringOutput)
 }
 
+// Custom-container runtime related function configuration. See `customContainerConfig` below.
 func (o V2FunctionOutput) CustomContainerConfig() V2FunctionCustomContainerConfigPtrOutput {
 	return o.ApplyT(func(v *V2Function) V2FunctionCustomContainerConfigPtrOutput { return v.CustomContainerConfig }).(V2FunctionCustomContainerConfigPtrOutput)
 }
 
+// Function custom DNS configuration. See `customDns` below.
 func (o V2FunctionOutput) CustomDns() V2FunctionCustomDnsPtrOutput {
 	return o.ApplyT(func(v *V2Function) V2FunctionCustomDnsPtrOutput { return v.CustomDns }).(V2FunctionCustomDnsPtrOutput)
 }
 
+// Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
 func (o V2FunctionOutput) CustomHealthCheckConfig() V2FunctionCustomHealthCheckConfigPtrOutput {
 	return o.ApplyT(func(v *V2Function) V2FunctionCustomHealthCheckConfigPtrOutput { return v.CustomHealthCheckConfig }).(V2FunctionCustomHealthCheckConfigPtrOutput)
 }
 
+// Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
 func (o V2FunctionOutput) CustomRuntimeConfig() V2FunctionCustomRuntimeConfigPtrOutput {
 	return o.ApplyT(func(v *V2Function) V2FunctionCustomRuntimeConfigPtrOutput { return v.CustomRuntimeConfig }).(V2FunctionCustomRuntimeConfigPtrOutput)
 }
 
+// description of function.
 func (o V2FunctionOutput) Description() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringPtrOutput { return v.Description }).(pulumi.StringPtrOutput)
 }
 
+// The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
 func (o V2FunctionOutput) DiskSize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntPtrOutput { return v.DiskSize }).(pulumi.IntPtrOutput)
 }
 
+// The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
 func (o V2FunctionOutput) EnvironmentVariables() pulumi.StringMapOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringMapOutput { return v.EnvironmentVariables }).(pulumi.StringMapOutput)
 }
 
+// The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
 func (o V2FunctionOutput) FunctionArn() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.FunctionArn }).(pulumi.StringOutput)
 }
 
+// function name.
 func (o V2FunctionOutput) FunctionName() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.FunctionName }).(pulumi.StringOutput)
 }
 
+// The GPU memory specification of the function, in MB, is a multiple of 1024MB.
 func (o V2FunctionOutput) GpuMemorySize() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntPtrOutput { return v.GpuMemorySize }).(pulumi.IntPtrOutput)
 }
 
+// entry point of function.
 func (o V2FunctionOutput) Handler() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.Handler }).(pulumi.StringOutput)
 }
 
+// max running time of initializer.
 func (o V2FunctionOutput) InitializationTimeout() pulumi.IntOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntOutput { return v.InitializationTimeout }).(pulumi.IntOutput)
 }
 
+// initializer entry point of function.
 func (o V2FunctionOutput) Initializer() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringPtrOutput { return v.Initializer }).(pulumi.StringPtrOutput)
 }
 
+// The maximum concurrency allowed for a single function instance.
 func (o V2FunctionOutput) InstanceConcurrency() pulumi.IntOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntOutput { return v.InstanceConcurrency }).(pulumi.IntOutput)
 }
 
+// Instance lifecycle configuration. See `instanceLifecycleConfig` below.
 func (o V2FunctionOutput) InstanceLifecycleConfig() V2FunctionInstanceLifecycleConfigPtrOutput {
 	return o.ApplyT(func(v *V2Function) V2FunctionInstanceLifecycleConfigPtrOutput { return v.InstanceLifecycleConfig }).(V2FunctionInstanceLifecycleConfigPtrOutput)
 }
 
+// The instance type of the function. Valid values:
+// - **e1**: Elastic instance.
+// - **c1**: performance instance.
+// - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+// - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+// - **g1**: Same as **fc.gpu.tesla.1**.
 func (o V2FunctionOutput) InstanceType() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.InstanceType }).(pulumi.StringOutput)
 }
 
+// List of layers.
+// > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
 func (o V2FunctionOutput) Layers() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringArrayOutput { return v.Layers }).(pulumi.StringArrayOutput)
 }
 
+// memory size needed by function.
 func (o V2FunctionOutput) MemorySize() pulumi.IntOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntOutput { return v.MemorySize }).(pulumi.IntOutput)
 }
 
+// runtime of function code.
 func (o V2FunctionOutput) Runtime() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.Runtime }).(pulumi.StringOutput)
 }
 
+// The name of the function Service.
 func (o V2FunctionOutput) ServiceName() pulumi.StringOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.StringOutput { return v.ServiceName }).(pulumi.StringOutput)
 }
 
+// max running time of function.
 func (o V2FunctionOutput) Timeout() pulumi.IntOutput {
 	return o.ApplyT(func(v *V2Function) pulumi.IntOutput { return v.Timeout }).(pulumi.IntOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/FcFunctions.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/FcFunctions.java
@@ -575,41 +575,6 @@ public final class FcFunctions {
      * 
      * &gt; **NOTE:** Available since v1.112.0+
      * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
-     * 
      */
     public static Output<GetServiceResult> getService() {
         return getService(GetServiceArgs.Empty, InvokeOptions.Empty);
@@ -620,41 +585,6 @@ public final class FcFunctions {
      * For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
      * 
      * &gt; **NOTE:** Available since v1.112.0+
-     * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
      * 
      */
     public static CompletableFuture<GetServiceResult> getServicePlain() {
@@ -667,41 +597,6 @@ public final class FcFunctions {
      * 
      * &gt; **NOTE:** Available since v1.112.0+
      * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
-     * 
      */
     public static Output<GetServiceResult> getService(GetServiceArgs args) {
         return getService(args, InvokeOptions.Empty);
@@ -712,41 +607,6 @@ public final class FcFunctions {
      * For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
      * 
      * &gt; **NOTE:** Available since v1.112.0+
-     * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
      * 
      */
     public static CompletableFuture<GetServiceResult> getServicePlain(GetServicePlainArgs args) {
@@ -759,41 +619,6 @@ public final class FcFunctions {
      * 
      * &gt; **NOTE:** Available since v1.112.0+
      * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
-     * 
      */
     public static Output<GetServiceResult> getService(GetServiceArgs args, InvokeOptions options) {
         return Deployment.getInstance().invoke("alicloud:fc/getService:getService", TypeShape.of(GetServiceResult.class), args, Utilities.withVersion(options));
@@ -805,41 +630,6 @@ public final class FcFunctions {
      * 
      * &gt; **NOTE:** Available since v1.112.0+
      * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
-     * 
      */
     public static Output<GetServiceResult> getService(GetServiceArgs args, InvokeOutputOptions options) {
         return Deployment.getInstance().invoke("alicloud:fc/getService:getService", TypeShape.of(GetServiceResult.class), args, Utilities.withVersion(options));
@@ -850,41 +640,6 @@ public final class FcFunctions {
      * For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
      * 
      * &gt; **NOTE:** Available since v1.112.0+
-     * 
-     * ## Example Usage
-     * 
-     * &lt;!--Start PulumiCodeChooser --&gt;
-     * <pre>
-     * {@code
-     * package generated_program;
-     * 
-     * import com.pulumi.Context;
-     * import com.pulumi.Pulumi;
-     * import com.pulumi.core.Output;
-     * import com.pulumi.alicloud.fc.FcFunctions;
-     * import com.pulumi.alicloud.fc.inputs.GetServiceArgs;
-     * import java.util.List;
-     * import java.util.ArrayList;
-     * import java.util.Map;
-     * import java.io.File;
-     * import java.nio.file.Files;
-     * import java.nio.file.Paths;
-     * 
-     * public class App {
-     *     public static void main(String[] args) {
-     *         Pulumi.run(App::stack);
-     *     }
-     * 
-     *     public static void stack(Context ctx) {
-     *         final var open = FcFunctions.getService(GetServiceArgs.builder()
-     *             .enable("On")
-     *             .build());
-     * 
-     *     }
-     * }
-     * }
-     * </pre>
-     * &lt;!--End PulumiCodeChooser --&gt;
      * 
      */
     public static CompletableFuture<GetServiceResult> getServicePlain(GetServicePlainArgs args, InvokeOptions options) {

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/Service.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/Service.java
@@ -20,89 +20,227 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
+/**
+ * Provides a Alicloud Function Compute Service resource. The resource is the base of launching Function and Trigger configuration.
+ * For information about Service and how to use it, see [What is Function Compute](https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-createservice).
+ * 
+ * &gt; **NOTE:** The resource requires a provider field &#39;account_id&#39;. See account_id.
+ * 
+ * &gt; **NOTE:** If you happen the error &#34;Argument &#39;internetAccess&#39; is not supported&#34;, you need to log on web console and click button &#34;Apply VPC Function&#34;
+ * which is in the upper of [Function Service Web Console](https://fc.console.aliyun.com/) page.
+ * 
+ * &gt; **NOTE:** Currently not all regions support Function Compute Service.
+ * For more details supported regions, see [Service endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm)
+ * 
+ * &gt; **NOTE:** Available since v1.93.0.
+ * ## Module Support
+ * 
+ * You can use to the existing fc module to create a service and a function quickly and then set several triggers for it.
+ * 
+ * ## Import
+ * 
+ * Function Compute Service can be imported using the id or name, e.g.
+ * 
+ * ```sh
+ * $ pulumi import alicloud:fc/service:Service foo my-fc-service
+ * ```
+ * 
+ */
 @ResourceType(type="alicloud:fc/service:Service")
 public class Service extends com.pulumi.resources.CustomResource {
+    /**
+     * The Function Compute Service description.
+     * 
+     */
     @Export(name="description", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> description;
 
+    /**
+     * @return The Function Compute Service description.
+     * 
+     */
     public Output<Optional<String>> description() {
         return Codegen.optional(this.description);
     }
+    /**
+     * Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+     * 
+     */
     @Export(name="internetAccess", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> internetAccess;
 
+    /**
+     * @return Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+     * 
+     */
     public Output<Optional<Boolean>> internetAccess() {
         return Codegen.optional(this.internetAccess);
     }
+    /**
+     * The date this resource was last modified.
+     * 
+     */
     @Export(name="lastModified", refs={String.class}, tree="[0]")
     private Output<String> lastModified;
 
+    /**
+     * @return The date this resource was last modified.
+     * 
+     */
     public Output<String> lastModified() {
         return this.lastModified;
     }
+    /**
+     * Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+     * 
+     */
     @Export(name="logConfig", refs={ServiceLogConfig.class}, tree="[0]")
     private Output</* @Nullable */ ServiceLogConfig> logConfig;
 
+    /**
+     * @return Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+     * 
+     */
     public Output<Optional<ServiceLogConfig>> logConfig() {
         return Codegen.optional(this.logConfig);
     }
+    /**
+     * The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+     * 
+     */
     @Export(name="name", refs={String.class}, tree="[0]")
     private Output<String> name;
 
+    /**
+     * @return The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+     * 
+     */
     public Output<String> name() {
         return this.name;
     }
+    /**
+     * Setting a prefix to get a only name. It is conflict with `name`.
+     * 
+     */
     @Export(name="namePrefix", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> namePrefix;
 
+    /**
+     * @return Setting a prefix to get a only name. It is conflict with `name`.
+     * 
+     */
     public Output<Optional<String>> namePrefix() {
         return Codegen.optional(this.namePrefix);
     }
+    /**
+     * Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+     * 
+     */
     @Export(name="nasConfig", refs={ServiceNasConfig.class}, tree="[0]")
     private Output</* @Nullable */ ServiceNasConfig> nasConfig;
 
+    /**
+     * @return Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+     * 
+     */
     public Output<Optional<ServiceNasConfig>> nasConfig() {
         return Codegen.optional(this.nasConfig);
     }
+    /**
+     * Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     * 
+     */
     @Export(name="publish", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> publish;
 
+    /**
+     * @return Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     * 
+     */
     public Output<Optional<Boolean>> publish() {
         return Codegen.optional(this.publish);
     }
+    /**
+     * RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     * 
+     */
     @Export(name="role", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> role;
 
+    /**
+     * @return RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     * 
+     */
     public Output<Optional<String>> role() {
         return Codegen.optional(this.role);
     }
+    /**
+     * The Function Compute Service ID.
+     * 
+     */
     @Export(name="serviceId", refs={String.class}, tree="[0]")
     private Output<String> serviceId;
 
+    /**
+     * @return The Function Compute Service ID.
+     * 
+     */
     public Output<String> serviceId() {
         return this.serviceId;
     }
+    /**
+     * Map for tagging resources.
+     * 
+     */
     @Export(name="tags", refs={Map.class,String.class}, tree="[0,1,1]")
     private Output</* @Nullable */ Map<String,String>> tags;
 
+    /**
+     * @return Map for tagging resources.
+     * 
+     */
     public Output<Optional<Map<String,String>>> tags() {
         return Codegen.optional(this.tags);
     }
+    /**
+     * Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+     * 
+     */
     @Export(name="tracingConfig", refs={ServiceTracingConfig.class}, tree="[0]")
     private Output</* @Nullable */ ServiceTracingConfig> tracingConfig;
 
+    /**
+     * @return Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+     * 
+     */
     public Output<Optional<ServiceTracingConfig>> tracingConfig() {
         return Codegen.optional(this.tracingConfig);
     }
+    /**
+     * The latest published version of your Function Compute Service.
+     * 
+     */
     @Export(name="version", refs={String.class}, tree="[0]")
     private Output<String> version;
 
+    /**
+     * @return The latest published version of your Function Compute Service.
+     * 
+     */
     public Output<String> version() {
         return this.version;
     }
+    /**
+     * Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+     * 
+     */
     @Export(name="vpcConfig", refs={ServiceVpcConfig.class}, tree="[0]")
     private Output</* @Nullable */ ServiceVpcConfig> vpcConfig;
 
+    /**
+     * @return Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+     * 
+     */
     public Output<Optional<ServiceVpcConfig>> vpcConfig() {
         return Codegen.optional(this.vpcConfig);
     }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/ServiceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/ServiceArgs.java
@@ -21,79 +21,167 @@ public final class ServiceArgs extends com.pulumi.resources.ResourceArgs {
 
     public static final ServiceArgs Empty = new ServiceArgs();
 
+    /**
+     * The Function Compute Service description.
+     * 
+     */
     @Import(name="description")
     private @Nullable Output<String> description;
 
+    /**
+     * @return The Function Compute Service description.
+     * 
+     */
     public Optional<Output<String>> description() {
         return Optional.ofNullable(this.description);
     }
 
+    /**
+     * Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+     * 
+     */
     @Import(name="internetAccess")
     private @Nullable Output<Boolean> internetAccess;
 
+    /**
+     * @return Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+     * 
+     */
     public Optional<Output<Boolean>> internetAccess() {
         return Optional.ofNullable(this.internetAccess);
     }
 
+    /**
+     * Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+     * 
+     */
     @Import(name="logConfig")
     private @Nullable Output<ServiceLogConfigArgs> logConfig;
 
+    /**
+     * @return Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+     * 
+     */
     public Optional<Output<ServiceLogConfigArgs>> logConfig() {
         return Optional.ofNullable(this.logConfig);
     }
 
+    /**
+     * The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+     * 
+     */
     @Import(name="name")
     private @Nullable Output<String> name;
 
+    /**
+     * @return The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+     * 
+     */
     public Optional<Output<String>> name() {
         return Optional.ofNullable(this.name);
     }
 
+    /**
+     * Setting a prefix to get a only name. It is conflict with `name`.
+     * 
+     */
     @Import(name="namePrefix")
     private @Nullable Output<String> namePrefix;
 
+    /**
+     * @return Setting a prefix to get a only name. It is conflict with `name`.
+     * 
+     */
     public Optional<Output<String>> namePrefix() {
         return Optional.ofNullable(this.namePrefix);
     }
 
+    /**
+     * Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+     * 
+     */
     @Import(name="nasConfig")
     private @Nullable Output<ServiceNasConfigArgs> nasConfig;
 
+    /**
+     * @return Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+     * 
+     */
     public Optional<Output<ServiceNasConfigArgs>> nasConfig() {
         return Optional.ofNullable(this.nasConfig);
     }
 
+    /**
+     * Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     * 
+     */
     @Import(name="publish")
     private @Nullable Output<Boolean> publish;
 
+    /**
+     * @return Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     * 
+     */
     public Optional<Output<Boolean>> publish() {
         return Optional.ofNullable(this.publish);
     }
 
+    /**
+     * RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     * 
+     */
     @Import(name="role")
     private @Nullable Output<String> role;
 
+    /**
+     * @return RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     * 
+     */
     public Optional<Output<String>> role() {
         return Optional.ofNullable(this.role);
     }
 
+    /**
+     * Map for tagging resources.
+     * 
+     */
     @Import(name="tags")
     private @Nullable Output<Map<String,String>> tags;
 
+    /**
+     * @return Map for tagging resources.
+     * 
+     */
     public Optional<Output<Map<String,String>>> tags() {
         return Optional.ofNullable(this.tags);
     }
 
+    /**
+     * Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+     * 
+     */
     @Import(name="tracingConfig")
     private @Nullable Output<ServiceTracingConfigArgs> tracingConfig;
 
+    /**
+     * @return Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+     * 
+     */
     public Optional<Output<ServiceTracingConfigArgs>> tracingConfig() {
         return Optional.ofNullable(this.tracingConfig);
     }
 
+    /**
+     * Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+     * 
+     */
     @Import(name="vpcConfig")
     private @Nullable Output<ServiceVpcConfigArgs> vpcConfig;
 
+    /**
+     * @return Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+     * 
+     */
     public Optional<Output<ServiceVpcConfigArgs>> vpcConfig() {
         return Optional.ofNullable(this.vpcConfig);
     }
@@ -132,101 +220,233 @@ public final class ServiceArgs extends com.pulumi.resources.ResourceArgs {
             $ = new ServiceArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param description The Function Compute Service description.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(@Nullable Output<String> description) {
             $.description = description;
             return this;
         }
 
+        /**
+         * @param description The Function Compute Service description.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(String description) {
             return description(Output.of(description));
         }
 
+        /**
+         * @param internetAccess Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+         * 
+         * @return builder
+         * 
+         */
         public Builder internetAccess(@Nullable Output<Boolean> internetAccess) {
             $.internetAccess = internetAccess;
             return this;
         }
 
+        /**
+         * @param internetAccess Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+         * 
+         * @return builder
+         * 
+         */
         public Builder internetAccess(Boolean internetAccess) {
             return internetAccess(Output.of(internetAccess));
         }
 
+        /**
+         * @param logConfig Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder logConfig(@Nullable Output<ServiceLogConfigArgs> logConfig) {
             $.logConfig = logConfig;
             return this;
         }
 
+        /**
+         * @param logConfig Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder logConfig(ServiceLogConfigArgs logConfig) {
             return logConfig(Output.of(logConfig));
         }
 
+        /**
+         * @param name The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
 
+        /**
+         * @param name The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder name(String name) {
             return name(Output.of(name));
         }
 
+        /**
+         * @param namePrefix Setting a prefix to get a only name. It is conflict with `name`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder namePrefix(@Nullable Output<String> namePrefix) {
             $.namePrefix = namePrefix;
             return this;
         }
 
+        /**
+         * @param namePrefix Setting a prefix to get a only name. It is conflict with `name`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder namePrefix(String namePrefix) {
             return namePrefix(Output.of(namePrefix));
         }
 
+        /**
+         * @param nasConfig Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder nasConfig(@Nullable Output<ServiceNasConfigArgs> nasConfig) {
             $.nasConfig = nasConfig;
             return this;
         }
 
+        /**
+         * @param nasConfig Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder nasConfig(ServiceNasConfigArgs nasConfig) {
             return nasConfig(Output.of(nasConfig));
         }
 
+        /**
+         * @param publish Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder publish(@Nullable Output<Boolean> publish) {
             $.publish = publish;
             return this;
         }
 
+        /**
+         * @param publish Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder publish(Boolean publish) {
             return publish(Output.of(publish));
         }
 
+        /**
+         * @param role RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+         * 
+         * @return builder
+         * 
+         */
         public Builder role(@Nullable Output<String> role) {
             $.role = role;
             return this;
         }
 
+        /**
+         * @param role RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+         * 
+         * @return builder
+         * 
+         */
         public Builder role(String role) {
             return role(Output.of(role));
         }
 
+        /**
+         * @param tags Map for tagging resources.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tags(@Nullable Output<Map<String,String>> tags) {
             $.tags = tags;
             return this;
         }
 
+        /**
+         * @param tags Map for tagging resources.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tags(Map<String,String> tags) {
             return tags(Output.of(tags));
         }
 
+        /**
+         * @param tracingConfig Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tracingConfig(@Nullable Output<ServiceTracingConfigArgs> tracingConfig) {
             $.tracingConfig = tracingConfig;
             return this;
         }
 
+        /**
+         * @param tracingConfig Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tracingConfig(ServiceTracingConfigArgs tracingConfig) {
             return tracingConfig(Output.of(tracingConfig));
         }
 
+        /**
+         * @param vpcConfig Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder vpcConfig(@Nullable Output<ServiceVpcConfigArgs> vpcConfig) {
             $.vpcConfig = vpcConfig;
             return this;
         }
 
+        /**
+         * @param vpcConfig Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder vpcConfig(ServiceVpcConfigArgs vpcConfig) {
             return vpcConfig(Output.of(vpcConfig));
         }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/V2Function.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/V2Function.java
@@ -24,161 +24,397 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
+/**
+ * Provides a FCV2 Function resource. Function is the unit of system scheduling and operation. Functions must be subordinate to services. All functions under the same service share some identical settings, such as service authorization and log configuration.
+ * 
+ * For information about FCV2 Function and how to use it, see [What is Function](https://www.alibabacloud.com/help/en/resource-orchestration-service/latest/aliyun-fc-function).
+ * 
+ * &gt; **NOTE:** Available since v1.208.0.
+ * 
+ * ## Import
+ * 
+ * FCV2 Function can be imported using the id, e.g.
+ * 
+ * ```sh
+ * $ pulumi import alicloud:fc/v2Function:V2Function example &lt;service_name&gt;:&lt;function_name&gt;
+ * ```
+ * 
+ */
 @ResourceType(type="alicloud:fc/v2Function:V2Function")
 public class V2Function extends com.pulumi.resources.CustomResource {
+    /**
+     * The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     * 
+     */
     @Export(name="caPort", refs={Integer.class}, tree="[0]")
     private Output<Integer> caPort;
 
+    /**
+     * @return The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     * 
+     */
     public Output<Integer> caPort() {
         return this.caPort;
     }
+    /**
+     * Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     * 
+     */
     @Export(name="code", refs={V2FunctionCode.class}, tree="[0]")
     private Output</* @Nullable */ V2FunctionCode> code;
 
+    /**
+     * @return Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     * 
+     */
     public Output<Optional<V2FunctionCode>> code() {
         return Codegen.optional(this.code);
     }
+    /**
+     * crc64 of function code.
+     * 
+     */
     @Export(name="codeChecksum", refs={String.class}, tree="[0]")
     private Output<String> codeChecksum;
 
+    /**
+     * @return crc64 of function code.
+     * 
+     */
     public Output<String> codeChecksum() {
         return this.codeChecksum;
     }
+    /**
+     * The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     * 
+     */
     @Export(name="cpu", refs={Double.class}, tree="[0]")
     private Output</* @Nullable */ Double> cpu;
 
+    /**
+     * @return The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     * 
+     */
     public Output<Optional<Double>> cpu() {
         return Codegen.optional(this.cpu);
     }
+    /**
+     * create time of function.
+     * 
+     */
     @Export(name="createTime", refs={String.class}, tree="[0]")
     private Output<String> createTime;
 
+    /**
+     * @return create time of function.
+     * 
+     */
     public Output<String> createTime() {
         return this.createTime;
     }
+    /**
+     * Custom-container runtime related function configuration. See `custom_container_config` below.
+     * 
+     */
     @Export(name="customContainerConfig", refs={V2FunctionCustomContainerConfig.class}, tree="[0]")
     private Output</* @Nullable */ V2FunctionCustomContainerConfig> customContainerConfig;
 
+    /**
+     * @return Custom-container runtime related function configuration. See `custom_container_config` below.
+     * 
+     */
     public Output<Optional<V2FunctionCustomContainerConfig>> customContainerConfig() {
         return Codegen.optional(this.customContainerConfig);
     }
+    /**
+     * Function custom DNS configuration. See `custom_dns` below.
+     * 
+     */
     @Export(name="customDns", refs={V2FunctionCustomDns.class}, tree="[0]")
     private Output</* @Nullable */ V2FunctionCustomDns> customDns;
 
+    /**
+     * @return Function custom DNS configuration. See `custom_dns` below.
+     * 
+     */
     public Output<Optional<V2FunctionCustomDns>> customDns() {
         return Codegen.optional(this.customDns);
     }
+    /**
+     * Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+     * 
+     */
     @Export(name="customHealthCheckConfig", refs={V2FunctionCustomHealthCheckConfig.class}, tree="[0]")
     private Output</* @Nullable */ V2FunctionCustomHealthCheckConfig> customHealthCheckConfig;
 
+    /**
+     * @return Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+     * 
+     */
     public Output<Optional<V2FunctionCustomHealthCheckConfig>> customHealthCheckConfig() {
         return Codegen.optional(this.customHealthCheckConfig);
     }
+    /**
+     * Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+     * 
+     */
     @Export(name="customRuntimeConfig", refs={V2FunctionCustomRuntimeConfig.class}, tree="[0]")
     private Output</* @Nullable */ V2FunctionCustomRuntimeConfig> customRuntimeConfig;
 
+    /**
+     * @return Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+     * 
+     */
     public Output<Optional<V2FunctionCustomRuntimeConfig>> customRuntimeConfig() {
         return Codegen.optional(this.customRuntimeConfig);
     }
+    /**
+     * description of function.
+     * 
+     */
     @Export(name="description", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> description;
 
+    /**
+     * @return description of function.
+     * 
+     */
     public Output<Optional<String>> description() {
         return Codegen.optional(this.description);
     }
+    /**
+     * The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     * 
+     */
     @Export(name="diskSize", refs={Integer.class}, tree="[0]")
     private Output</* @Nullable */ Integer> diskSize;
 
+    /**
+     * @return The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     * 
+     */
     public Output<Optional<Integer>> diskSize() {
         return Codegen.optional(this.diskSize);
     }
+    /**
+     * The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     * 
+     */
     @Export(name="environmentVariables", refs={Map.class,String.class}, tree="[0,1,1]")
     private Output</* @Nullable */ Map<String,String>> environmentVariables;
 
+    /**
+     * @return The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     * 
+     */
     public Output<Optional<Map<String,String>>> environmentVariables() {
         return Codegen.optional(this.environmentVariables);
     }
+    /**
+     * The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+     * 
+     */
     @Export(name="functionArn", refs={String.class}, tree="[0]")
     private Output<String> functionArn;
 
+    /**
+     * @return The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+     * 
+     */
     public Output<String> functionArn() {
         return this.functionArn;
     }
+    /**
+     * function name.
+     * 
+     */
     @Export(name="functionName", refs={String.class}, tree="[0]")
     private Output<String> functionName;
 
+    /**
+     * @return function name.
+     * 
+     */
     public Output<String> functionName() {
         return this.functionName;
     }
+    /**
+     * The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     * 
+     */
     @Export(name="gpuMemorySize", refs={Integer.class}, tree="[0]")
     private Output</* @Nullable */ Integer> gpuMemorySize;
 
+    /**
+     * @return The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     * 
+     */
     public Output<Optional<Integer>> gpuMemorySize() {
         return Codegen.optional(this.gpuMemorySize);
     }
+    /**
+     * entry point of function.
+     * 
+     */
     @Export(name="handler", refs={String.class}, tree="[0]")
     private Output<String> handler;
 
+    /**
+     * @return entry point of function.
+     * 
+     */
     public Output<String> handler() {
         return this.handler;
     }
+    /**
+     * max running time of initializer.
+     * 
+     */
     @Export(name="initializationTimeout", refs={Integer.class}, tree="[0]")
     private Output<Integer> initializationTimeout;
 
+    /**
+     * @return max running time of initializer.
+     * 
+     */
     public Output<Integer> initializationTimeout() {
         return this.initializationTimeout;
     }
+    /**
+     * initializer entry point of function.
+     * 
+     */
     @Export(name="initializer", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> initializer;
 
+    /**
+     * @return initializer entry point of function.
+     * 
+     */
     public Output<Optional<String>> initializer() {
         return Codegen.optional(this.initializer);
     }
+    /**
+     * The maximum concurrency allowed for a single function instance.
+     * 
+     */
     @Export(name="instanceConcurrency", refs={Integer.class}, tree="[0]")
     private Output<Integer> instanceConcurrency;
 
+    /**
+     * @return The maximum concurrency allowed for a single function instance.
+     * 
+     */
     public Output<Integer> instanceConcurrency() {
         return this.instanceConcurrency;
     }
+    /**
+     * Instance lifecycle configuration. See `instance_lifecycle_config` below.
+     * 
+     */
     @Export(name="instanceLifecycleConfig", refs={V2FunctionInstanceLifecycleConfig.class}, tree="[0]")
     private Output</* @Nullable */ V2FunctionInstanceLifecycleConfig> instanceLifecycleConfig;
 
+    /**
+     * @return Instance lifecycle configuration. See `instance_lifecycle_config` below.
+     * 
+     */
     public Output<Optional<V2FunctionInstanceLifecycleConfig>> instanceLifecycleConfig() {
         return Codegen.optional(this.instanceLifecycleConfig);
     }
+    /**
+     * The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     * 
+     */
     @Export(name="instanceType", refs={String.class}, tree="[0]")
     private Output<String> instanceType;
 
+    /**
+     * @return The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     * 
+     */
     public Output<String> instanceType() {
         return this.instanceType;
     }
+    /**
+     * List of layers.
+     * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     * 
+     */
     @Export(name="layers", refs={List.class,String.class}, tree="[0,1]")
     private Output</* @Nullable */ List<String>> layers;
 
+    /**
+     * @return List of layers.
+     * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     * 
+     */
     public Output<Optional<List<String>>> layers() {
         return Codegen.optional(this.layers);
     }
+    /**
+     * memory size needed by function.
+     * 
+     */
     @Export(name="memorySize", refs={Integer.class}, tree="[0]")
     private Output<Integer> memorySize;
 
+    /**
+     * @return memory size needed by function.
+     * 
+     */
     public Output<Integer> memorySize() {
         return this.memorySize;
     }
+    /**
+     * runtime of function code.
+     * 
+     */
     @Export(name="runtime", refs={String.class}, tree="[0]")
     private Output<String> runtime;
 
+    /**
+     * @return runtime of function code.
+     * 
+     */
     public Output<String> runtime() {
         return this.runtime;
     }
+    /**
+     * The name of the function Service.
+     * 
+     */
     @Export(name="serviceName", refs={String.class}, tree="[0]")
     private Output<String> serviceName;
 
+    /**
+     * @return The name of the function Service.
+     * 
+     */
     public Output<String> serviceName() {
         return this.serviceName;
     }
+    /**
+     * max running time of function.
+     * 
+     */
     @Export(name="timeout", refs={Integer.class}, tree="[0]")
     private Output<Integer> timeout;
 
+    /**
+     * @return max running time of function.
+     * 
+     */
     public Output<Integer> timeout() {
         return this.timeout;
     }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/V2FunctionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/V2FunctionArgs.java
@@ -26,170 +26,374 @@ public final class V2FunctionArgs extends com.pulumi.resources.ResourceArgs {
 
     public static final V2FunctionArgs Empty = new V2FunctionArgs();
 
+    /**
+     * The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     * 
+     */
     @Import(name="caPort")
     private @Nullable Output<Integer> caPort;
 
+    /**
+     * @return The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     * 
+     */
     public Optional<Output<Integer>> caPort() {
         return Optional.ofNullable(this.caPort);
     }
 
+    /**
+     * Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     * 
+     */
     @Import(name="code")
     private @Nullable Output<V2FunctionCodeArgs> code;
 
+    /**
+     * @return Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     * 
+     */
     public Optional<Output<V2FunctionCodeArgs>> code() {
         return Optional.ofNullable(this.code);
     }
 
+    /**
+     * crc64 of function code.
+     * 
+     */
     @Import(name="codeChecksum")
     private @Nullable Output<String> codeChecksum;
 
+    /**
+     * @return crc64 of function code.
+     * 
+     */
     public Optional<Output<String>> codeChecksum() {
         return Optional.ofNullable(this.codeChecksum);
     }
 
+    /**
+     * The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     * 
+     */
     @Import(name="cpu")
     private @Nullable Output<Double> cpu;
 
+    /**
+     * @return The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     * 
+     */
     public Optional<Output<Double>> cpu() {
         return Optional.ofNullable(this.cpu);
     }
 
+    /**
+     * Custom-container runtime related function configuration. See `custom_container_config` below.
+     * 
+     */
     @Import(name="customContainerConfig")
     private @Nullable Output<V2FunctionCustomContainerConfigArgs> customContainerConfig;
 
+    /**
+     * @return Custom-container runtime related function configuration. See `custom_container_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomContainerConfigArgs>> customContainerConfig() {
         return Optional.ofNullable(this.customContainerConfig);
     }
 
+    /**
+     * Function custom DNS configuration. See `custom_dns` below.
+     * 
+     */
     @Import(name="customDns")
     private @Nullable Output<V2FunctionCustomDnsArgs> customDns;
 
+    /**
+     * @return Function custom DNS configuration. See `custom_dns` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomDnsArgs>> customDns() {
         return Optional.ofNullable(this.customDns);
     }
 
+    /**
+     * Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+     * 
+     */
     @Import(name="customHealthCheckConfig")
     private @Nullable Output<V2FunctionCustomHealthCheckConfigArgs> customHealthCheckConfig;
 
+    /**
+     * @return Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomHealthCheckConfigArgs>> customHealthCheckConfig() {
         return Optional.ofNullable(this.customHealthCheckConfig);
     }
 
+    /**
+     * Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+     * 
+     */
     @Import(name="customRuntimeConfig")
     private @Nullable Output<V2FunctionCustomRuntimeConfigArgs> customRuntimeConfig;
 
+    /**
+     * @return Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomRuntimeConfigArgs>> customRuntimeConfig() {
         return Optional.ofNullable(this.customRuntimeConfig);
     }
 
+    /**
+     * description of function.
+     * 
+     */
     @Import(name="description")
     private @Nullable Output<String> description;
 
+    /**
+     * @return description of function.
+     * 
+     */
     public Optional<Output<String>> description() {
         return Optional.ofNullable(this.description);
     }
 
+    /**
+     * The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     * 
+     */
     @Import(name="diskSize")
     private @Nullable Output<Integer> diskSize;
 
+    /**
+     * @return The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     * 
+     */
     public Optional<Output<Integer>> diskSize() {
         return Optional.ofNullable(this.diskSize);
     }
 
+    /**
+     * The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     * 
+     */
     @Import(name="environmentVariables")
     private @Nullable Output<Map<String,String>> environmentVariables;
 
+    /**
+     * @return The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     * 
+     */
     public Optional<Output<Map<String,String>>> environmentVariables() {
         return Optional.ofNullable(this.environmentVariables);
     }
 
+    /**
+     * function name.
+     * 
+     */
     @Import(name="functionName", required=true)
     private Output<String> functionName;
 
+    /**
+     * @return function name.
+     * 
+     */
     public Output<String> functionName() {
         return this.functionName;
     }
 
+    /**
+     * The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     * 
+     */
     @Import(name="gpuMemorySize")
     private @Nullable Output<Integer> gpuMemorySize;
 
+    /**
+     * @return The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     * 
+     */
     public Optional<Output<Integer>> gpuMemorySize() {
         return Optional.ofNullable(this.gpuMemorySize);
     }
 
+    /**
+     * entry point of function.
+     * 
+     */
     @Import(name="handler", required=true)
     private Output<String> handler;
 
+    /**
+     * @return entry point of function.
+     * 
+     */
     public Output<String> handler() {
         return this.handler;
     }
 
+    /**
+     * max running time of initializer.
+     * 
+     */
     @Import(name="initializationTimeout")
     private @Nullable Output<Integer> initializationTimeout;
 
+    /**
+     * @return max running time of initializer.
+     * 
+     */
     public Optional<Output<Integer>> initializationTimeout() {
         return Optional.ofNullable(this.initializationTimeout);
     }
 
+    /**
+     * initializer entry point of function.
+     * 
+     */
     @Import(name="initializer")
     private @Nullable Output<String> initializer;
 
+    /**
+     * @return initializer entry point of function.
+     * 
+     */
     public Optional<Output<String>> initializer() {
         return Optional.ofNullable(this.initializer);
     }
 
+    /**
+     * The maximum concurrency allowed for a single function instance.
+     * 
+     */
     @Import(name="instanceConcurrency")
     private @Nullable Output<Integer> instanceConcurrency;
 
+    /**
+     * @return The maximum concurrency allowed for a single function instance.
+     * 
+     */
     public Optional<Output<Integer>> instanceConcurrency() {
         return Optional.ofNullable(this.instanceConcurrency);
     }
 
+    /**
+     * Instance lifecycle configuration. See `instance_lifecycle_config` below.
+     * 
+     */
     @Import(name="instanceLifecycleConfig")
     private @Nullable Output<V2FunctionInstanceLifecycleConfigArgs> instanceLifecycleConfig;
 
+    /**
+     * @return Instance lifecycle configuration. See `instance_lifecycle_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionInstanceLifecycleConfigArgs>> instanceLifecycleConfig() {
         return Optional.ofNullable(this.instanceLifecycleConfig);
     }
 
+    /**
+     * The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     * 
+     */
     @Import(name="instanceType")
     private @Nullable Output<String> instanceType;
 
+    /**
+     * @return The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     * 
+     */
     public Optional<Output<String>> instanceType() {
         return Optional.ofNullable(this.instanceType);
     }
 
+    /**
+     * List of layers.
+     * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     * 
+     */
     @Import(name="layers")
     private @Nullable Output<List<String>> layers;
 
+    /**
+     * @return List of layers.
+     * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     * 
+     */
     public Optional<Output<List<String>>> layers() {
         return Optional.ofNullable(this.layers);
     }
 
+    /**
+     * memory size needed by function.
+     * 
+     */
     @Import(name="memorySize")
     private @Nullable Output<Integer> memorySize;
 
+    /**
+     * @return memory size needed by function.
+     * 
+     */
     public Optional<Output<Integer>> memorySize() {
         return Optional.ofNullable(this.memorySize);
     }
 
+    /**
+     * runtime of function code.
+     * 
+     */
     @Import(name="runtime", required=true)
     private Output<String> runtime;
 
+    /**
+     * @return runtime of function code.
+     * 
+     */
     public Output<String> runtime() {
         return this.runtime;
     }
 
+    /**
+     * The name of the function Service.
+     * 
+     */
     @Import(name="serviceName", required=true)
     private Output<String> serviceName;
 
+    /**
+     * @return The name of the function Service.
+     * 
+     */
     public Output<String> serviceName() {
         return this.serviceName;
     }
 
+    /**
+     * max running time of function.
+     * 
+     */
     @Import(name="timeout")
     private @Nullable Output<Integer> timeout;
 
+    /**
+     * @return max running time of function.
+     * 
+     */
     public Optional<Output<Integer>> timeout() {
         return Optional.ofNullable(this.timeout);
     }
@@ -241,222 +445,529 @@ public final class V2FunctionArgs extends com.pulumi.resources.ResourceArgs {
             $ = new V2FunctionArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param caPort The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+         * 
+         * @return builder
+         * 
+         */
         public Builder caPort(@Nullable Output<Integer> caPort) {
             $.caPort = caPort;
             return this;
         }
 
+        /**
+         * @param caPort The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+         * 
+         * @return builder
+         * 
+         */
         public Builder caPort(Integer caPort) {
             return caPort(Output.of(caPort));
         }
 
+        /**
+         * @param code Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder code(@Nullable Output<V2FunctionCodeArgs> code) {
             $.code = code;
             return this;
         }
 
+        /**
+         * @param code Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder code(V2FunctionCodeArgs code) {
             return code(Output.of(code));
         }
 
+        /**
+         * @param codeChecksum crc64 of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder codeChecksum(@Nullable Output<String> codeChecksum) {
             $.codeChecksum = codeChecksum;
             return this;
         }
 
+        /**
+         * @param codeChecksum crc64 of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder codeChecksum(String codeChecksum) {
             return codeChecksum(Output.of(codeChecksum));
         }
 
+        /**
+         * @param cpu The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+         * 
+         * @return builder
+         * 
+         */
         public Builder cpu(@Nullable Output<Double> cpu) {
             $.cpu = cpu;
             return this;
         }
 
+        /**
+         * @param cpu The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+         * 
+         * @return builder
+         * 
+         */
         public Builder cpu(Double cpu) {
             return cpu(Output.of(cpu));
         }
 
+        /**
+         * @param customContainerConfig Custom-container runtime related function configuration. See `custom_container_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customContainerConfig(@Nullable Output<V2FunctionCustomContainerConfigArgs> customContainerConfig) {
             $.customContainerConfig = customContainerConfig;
             return this;
         }
 
+        /**
+         * @param customContainerConfig Custom-container runtime related function configuration. See `custom_container_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customContainerConfig(V2FunctionCustomContainerConfigArgs customContainerConfig) {
             return customContainerConfig(Output.of(customContainerConfig));
         }
 
+        /**
+         * @param customDns Function custom DNS configuration. See `custom_dns` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customDns(@Nullable Output<V2FunctionCustomDnsArgs> customDns) {
             $.customDns = customDns;
             return this;
         }
 
+        /**
+         * @param customDns Function custom DNS configuration. See `custom_dns` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customDns(V2FunctionCustomDnsArgs customDns) {
             return customDns(Output.of(customDns));
         }
 
+        /**
+         * @param customHealthCheckConfig Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customHealthCheckConfig(@Nullable Output<V2FunctionCustomHealthCheckConfigArgs> customHealthCheckConfig) {
             $.customHealthCheckConfig = customHealthCheckConfig;
             return this;
         }
 
+        /**
+         * @param customHealthCheckConfig Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customHealthCheckConfig(V2FunctionCustomHealthCheckConfigArgs customHealthCheckConfig) {
             return customHealthCheckConfig(Output.of(customHealthCheckConfig));
         }
 
+        /**
+         * @param customRuntimeConfig Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customRuntimeConfig(@Nullable Output<V2FunctionCustomRuntimeConfigArgs> customRuntimeConfig) {
             $.customRuntimeConfig = customRuntimeConfig;
             return this;
         }
 
+        /**
+         * @param customRuntimeConfig Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customRuntimeConfig(V2FunctionCustomRuntimeConfigArgs customRuntimeConfig) {
             return customRuntimeConfig(Output.of(customRuntimeConfig));
         }
 
+        /**
+         * @param description description of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(@Nullable Output<String> description) {
             $.description = description;
             return this;
         }
 
+        /**
+         * @param description description of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(String description) {
             return description(Output.of(description));
         }
 
+        /**
+         * @param diskSize The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder diskSize(@Nullable Output<Integer> diskSize) {
             $.diskSize = diskSize;
             return this;
         }
 
+        /**
+         * @param diskSize The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder diskSize(Integer diskSize) {
             return diskSize(Output.of(diskSize));
         }
 
+        /**
+         * @param environmentVariables The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+         * 
+         * @return builder
+         * 
+         */
         public Builder environmentVariables(@Nullable Output<Map<String,String>> environmentVariables) {
             $.environmentVariables = environmentVariables;
             return this;
         }
 
+        /**
+         * @param environmentVariables The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+         * 
+         * @return builder
+         * 
+         */
         public Builder environmentVariables(Map<String,String> environmentVariables) {
             return environmentVariables(Output.of(environmentVariables));
         }
 
+        /**
+         * @param functionName function name.
+         * 
+         * @return builder
+         * 
+         */
         public Builder functionName(Output<String> functionName) {
             $.functionName = functionName;
             return this;
         }
 
+        /**
+         * @param functionName function name.
+         * 
+         * @return builder
+         * 
+         */
         public Builder functionName(String functionName) {
             return functionName(Output.of(functionName));
         }
 
+        /**
+         * @param gpuMemorySize The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder gpuMemorySize(@Nullable Output<Integer> gpuMemorySize) {
             $.gpuMemorySize = gpuMemorySize;
             return this;
         }
 
+        /**
+         * @param gpuMemorySize The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder gpuMemorySize(Integer gpuMemorySize) {
             return gpuMemorySize(Output.of(gpuMemorySize));
         }
 
+        /**
+         * @param handler entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder handler(Output<String> handler) {
             $.handler = handler;
             return this;
         }
 
+        /**
+         * @param handler entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder handler(String handler) {
             return handler(Output.of(handler));
         }
 
+        /**
+         * @param initializationTimeout max running time of initializer.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializationTimeout(@Nullable Output<Integer> initializationTimeout) {
             $.initializationTimeout = initializationTimeout;
             return this;
         }
 
+        /**
+         * @param initializationTimeout max running time of initializer.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializationTimeout(Integer initializationTimeout) {
             return initializationTimeout(Output.of(initializationTimeout));
         }
 
+        /**
+         * @param initializer initializer entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializer(@Nullable Output<String> initializer) {
             $.initializer = initializer;
             return this;
         }
 
+        /**
+         * @param initializer initializer entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializer(String initializer) {
             return initializer(Output.of(initializer));
         }
 
+        /**
+         * @param instanceConcurrency The maximum concurrency allowed for a single function instance.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceConcurrency(@Nullable Output<Integer> instanceConcurrency) {
             $.instanceConcurrency = instanceConcurrency;
             return this;
         }
 
+        /**
+         * @param instanceConcurrency The maximum concurrency allowed for a single function instance.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceConcurrency(Integer instanceConcurrency) {
             return instanceConcurrency(Output.of(instanceConcurrency));
         }
 
+        /**
+         * @param instanceLifecycleConfig Instance lifecycle configuration. See `instance_lifecycle_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceLifecycleConfig(@Nullable Output<V2FunctionInstanceLifecycleConfigArgs> instanceLifecycleConfig) {
             $.instanceLifecycleConfig = instanceLifecycleConfig;
             return this;
         }
 
+        /**
+         * @param instanceLifecycleConfig Instance lifecycle configuration. See `instance_lifecycle_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceLifecycleConfig(V2FunctionInstanceLifecycleConfigArgs instanceLifecycleConfig) {
             return instanceLifecycleConfig(Output.of(instanceLifecycleConfig));
         }
 
+        /**
+         * @param instanceType The instance type of the function. Valid values:
+         * - **e1**: Elastic instance.
+         * - **c1**: performance instance.
+         * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+         * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+         * - **g1**: Same as **fc.gpu.tesla.1**.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceType(@Nullable Output<String> instanceType) {
             $.instanceType = instanceType;
             return this;
         }
 
+        /**
+         * @param instanceType The instance type of the function. Valid values:
+         * - **e1**: Elastic instance.
+         * - **c1**: performance instance.
+         * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+         * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+         * - **g1**: Same as **fc.gpu.tesla.1**.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceType(String instanceType) {
             return instanceType(Output.of(instanceType));
         }
 
+        /**
+         * @param layers List of layers.
+         * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+         * 
+         * @return builder
+         * 
+         */
         public Builder layers(@Nullable Output<List<String>> layers) {
             $.layers = layers;
             return this;
         }
 
+        /**
+         * @param layers List of layers.
+         * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+         * 
+         * @return builder
+         * 
+         */
         public Builder layers(List<String> layers) {
             return layers(Output.of(layers));
         }
 
+        /**
+         * @param layers List of layers.
+         * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+         * 
+         * @return builder
+         * 
+         */
         public Builder layers(String... layers) {
             return layers(List.of(layers));
         }
 
+        /**
+         * @param memorySize memory size needed by function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder memorySize(@Nullable Output<Integer> memorySize) {
             $.memorySize = memorySize;
             return this;
         }
 
+        /**
+         * @param memorySize memory size needed by function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder memorySize(Integer memorySize) {
             return memorySize(Output.of(memorySize));
         }
 
+        /**
+         * @param runtime runtime of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder runtime(Output<String> runtime) {
             $.runtime = runtime;
             return this;
         }
 
+        /**
+         * @param runtime runtime of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder runtime(String runtime) {
             return runtime(Output.of(runtime));
         }
 
+        /**
+         * @param serviceName The name of the function Service.
+         * 
+         * @return builder
+         * 
+         */
         public Builder serviceName(Output<String> serviceName) {
             $.serviceName = serviceName;
             return this;
         }
 
+        /**
+         * @param serviceName The name of the function Service.
+         * 
+         * @return builder
+         * 
+         */
         public Builder serviceName(String serviceName) {
             return serviceName(Output.of(serviceName));
         }
 
+        /**
+         * @param timeout max running time of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder timeout(@Nullable Output<Integer> timeout) {
             $.timeout = timeout;
             return this;
         }
 
+        /**
+         * @param timeout max running time of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder timeout(Integer timeout) {
             return timeout(Output.of(timeout));
         }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/inputs/ServiceState.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/inputs/ServiceState.java
@@ -21,100 +21,212 @@ public final class ServiceState extends com.pulumi.resources.ResourceArgs {
 
     public static final ServiceState Empty = new ServiceState();
 
+    /**
+     * The Function Compute Service description.
+     * 
+     */
     @Import(name="description")
     private @Nullable Output<String> description;
 
+    /**
+     * @return The Function Compute Service description.
+     * 
+     */
     public Optional<Output<String>> description() {
         return Optional.ofNullable(this.description);
     }
 
+    /**
+     * Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+     * 
+     */
     @Import(name="internetAccess")
     private @Nullable Output<Boolean> internetAccess;
 
+    /**
+     * @return Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+     * 
+     */
     public Optional<Output<Boolean>> internetAccess() {
         return Optional.ofNullable(this.internetAccess);
     }
 
+    /**
+     * The date this resource was last modified.
+     * 
+     */
     @Import(name="lastModified")
     private @Nullable Output<String> lastModified;
 
+    /**
+     * @return The date this resource was last modified.
+     * 
+     */
     public Optional<Output<String>> lastModified() {
         return Optional.ofNullable(this.lastModified);
     }
 
+    /**
+     * Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+     * 
+     */
     @Import(name="logConfig")
     private @Nullable Output<ServiceLogConfigArgs> logConfig;
 
+    /**
+     * @return Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+     * 
+     */
     public Optional<Output<ServiceLogConfigArgs>> logConfig() {
         return Optional.ofNullable(this.logConfig);
     }
 
+    /**
+     * The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+     * 
+     */
     @Import(name="name")
     private @Nullable Output<String> name;
 
+    /**
+     * @return The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+     * 
+     */
     public Optional<Output<String>> name() {
         return Optional.ofNullable(this.name);
     }
 
+    /**
+     * Setting a prefix to get a only name. It is conflict with `name`.
+     * 
+     */
     @Import(name="namePrefix")
     private @Nullable Output<String> namePrefix;
 
+    /**
+     * @return Setting a prefix to get a only name. It is conflict with `name`.
+     * 
+     */
     public Optional<Output<String>> namePrefix() {
         return Optional.ofNullable(this.namePrefix);
     }
 
+    /**
+     * Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+     * 
+     */
     @Import(name="nasConfig")
     private @Nullable Output<ServiceNasConfigArgs> nasConfig;
 
+    /**
+     * @return Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+     * 
+     */
     public Optional<Output<ServiceNasConfigArgs>> nasConfig() {
         return Optional.ofNullable(this.nasConfig);
     }
 
+    /**
+     * Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     * 
+     */
     @Import(name="publish")
     private @Nullable Output<Boolean> publish;
 
+    /**
+     * @return Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     * 
+     */
     public Optional<Output<Boolean>> publish() {
         return Optional.ofNullable(this.publish);
     }
 
+    /**
+     * RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     * 
+     */
     @Import(name="role")
     private @Nullable Output<String> role;
 
+    /**
+     * @return RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     * 
+     */
     public Optional<Output<String>> role() {
         return Optional.ofNullable(this.role);
     }
 
+    /**
+     * The Function Compute Service ID.
+     * 
+     */
     @Import(name="serviceId")
     private @Nullable Output<String> serviceId;
 
+    /**
+     * @return The Function Compute Service ID.
+     * 
+     */
     public Optional<Output<String>> serviceId() {
         return Optional.ofNullable(this.serviceId);
     }
 
+    /**
+     * Map for tagging resources.
+     * 
+     */
     @Import(name="tags")
     private @Nullable Output<Map<String,String>> tags;
 
+    /**
+     * @return Map for tagging resources.
+     * 
+     */
     public Optional<Output<Map<String,String>>> tags() {
         return Optional.ofNullable(this.tags);
     }
 
+    /**
+     * Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+     * 
+     */
     @Import(name="tracingConfig")
     private @Nullable Output<ServiceTracingConfigArgs> tracingConfig;
 
+    /**
+     * @return Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+     * 
+     */
     public Optional<Output<ServiceTracingConfigArgs>> tracingConfig() {
         return Optional.ofNullable(this.tracingConfig);
     }
 
+    /**
+     * The latest published version of your Function Compute Service.
+     * 
+     */
     @Import(name="version")
     private @Nullable Output<String> version;
 
+    /**
+     * @return The latest published version of your Function Compute Service.
+     * 
+     */
     public Optional<Output<String>> version() {
         return Optional.ofNullable(this.version);
     }
 
+    /**
+     * Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+     * 
+     */
     @Import(name="vpcConfig")
     private @Nullable Output<ServiceVpcConfigArgs> vpcConfig;
 
+    /**
+     * @return Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+     * 
+     */
     public Optional<Output<ServiceVpcConfigArgs>> vpcConfig() {
         return Optional.ofNullable(this.vpcConfig);
     }
@@ -156,128 +268,296 @@ public final class ServiceState extends com.pulumi.resources.ResourceArgs {
             $ = new ServiceState(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param description The Function Compute Service description.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(@Nullable Output<String> description) {
             $.description = description;
             return this;
         }
 
+        /**
+         * @param description The Function Compute Service description.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(String description) {
             return description(Output.of(description));
         }
 
+        /**
+         * @param internetAccess Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+         * 
+         * @return builder
+         * 
+         */
         public Builder internetAccess(@Nullable Output<Boolean> internetAccess) {
             $.internetAccess = internetAccess;
             return this;
         }
 
+        /**
+         * @param internetAccess Whether to allow the Service to access Internet. Default to &#34;true&#34;.
+         * 
+         * @return builder
+         * 
+         */
         public Builder internetAccess(Boolean internetAccess) {
             return internetAccess(Output.of(internetAccess));
         }
 
+        /**
+         * @param lastModified The date this resource was last modified.
+         * 
+         * @return builder
+         * 
+         */
         public Builder lastModified(@Nullable Output<String> lastModified) {
             $.lastModified = lastModified;
             return this;
         }
 
+        /**
+         * @param lastModified The date this resource was last modified.
+         * 
+         * @return builder
+         * 
+         */
         public Builder lastModified(String lastModified) {
             return lastModified(Output.of(lastModified));
         }
 
+        /**
+         * @param logConfig Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder logConfig(@Nullable Output<ServiceLogConfigArgs> logConfig) {
             $.logConfig = logConfig;
             return this;
         }
 
+        /**
+         * @param logConfig Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder logConfig(ServiceLogConfigArgs logConfig) {
             return logConfig(Output.of(logConfig));
         }
 
+        /**
+         * @param name The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
 
+        /**
+         * @param name The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder name(String name) {
             return name(Output.of(name));
         }
 
+        /**
+         * @param namePrefix Setting a prefix to get a only name. It is conflict with `name`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder namePrefix(@Nullable Output<String> namePrefix) {
             $.namePrefix = namePrefix;
             return this;
         }
 
+        /**
+         * @param namePrefix Setting a prefix to get a only name. It is conflict with `name`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder namePrefix(String namePrefix) {
             return namePrefix(Output.of(namePrefix));
         }
 
+        /**
+         * @param nasConfig Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder nasConfig(@Nullable Output<ServiceNasConfigArgs> nasConfig) {
             $.nasConfig = nasConfig;
             return this;
         }
 
+        /**
+         * @param nasConfig Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder nasConfig(ServiceNasConfigArgs nasConfig) {
             return nasConfig(Output.of(nasConfig));
         }
 
+        /**
+         * @param publish Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder publish(@Nullable Output<Boolean> publish) {
             $.publish = publish;
             return this;
         }
 
+        /**
+         * @param publish Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder publish(Boolean publish) {
             return publish(Output.of(publish));
         }
 
+        /**
+         * @param role RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+         * 
+         * @return builder
+         * 
+         */
         public Builder role(@Nullable Output<String> role) {
             $.role = role;
             return this;
         }
 
+        /**
+         * @param role RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+         * 
+         * @return builder
+         * 
+         */
         public Builder role(String role) {
             return role(Output.of(role));
         }
 
+        /**
+         * @param serviceId The Function Compute Service ID.
+         * 
+         * @return builder
+         * 
+         */
         public Builder serviceId(@Nullable Output<String> serviceId) {
             $.serviceId = serviceId;
             return this;
         }
 
+        /**
+         * @param serviceId The Function Compute Service ID.
+         * 
+         * @return builder
+         * 
+         */
         public Builder serviceId(String serviceId) {
             return serviceId(Output.of(serviceId));
         }
 
+        /**
+         * @param tags Map for tagging resources.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tags(@Nullable Output<Map<String,String>> tags) {
             $.tags = tags;
             return this;
         }
 
+        /**
+         * @param tags Map for tagging resources.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tags(Map<String,String> tags) {
             return tags(Output.of(tags));
         }
 
+        /**
+         * @param tracingConfig Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tracingConfig(@Nullable Output<ServiceTracingConfigArgs> tracingConfig) {
             $.tracingConfig = tracingConfig;
             return this;
         }
 
+        /**
+         * @param tracingConfig Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder tracingConfig(ServiceTracingConfigArgs tracingConfig) {
             return tracingConfig(Output.of(tracingConfig));
         }
 
+        /**
+         * @param version The latest published version of your Function Compute Service.
+         * 
+         * @return builder
+         * 
+         */
         public Builder version(@Nullable Output<String> version) {
             $.version = version;
             return this;
         }
 
+        /**
+         * @param version The latest published version of your Function Compute Service.
+         * 
+         * @return builder
+         * 
+         */
         public Builder version(String version) {
             return version(Output.of(version));
         }
 
+        /**
+         * @param vpcConfig Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder vpcConfig(@Nullable Output<ServiceVpcConfigArgs> vpcConfig) {
             $.vpcConfig = vpcConfig;
             return this;
         }
 
+        /**
+         * @param vpcConfig Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder vpcConfig(ServiceVpcConfigArgs vpcConfig) {
             return vpcConfig(Output.of(vpcConfig));
         }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/inputs/ServiceTracingConfigArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/inputs/ServiceTracingConfigArgs.java
@@ -16,14 +16,14 @@ public final class ServiceTracingConfigArgs extends com.pulumi.resources.Resourc
     public static final ServiceTracingConfigArgs Empty = new ServiceTracingConfigArgs();
 
     /**
-     * Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+     * Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
      * 
      */
     @Import(name="params", required=true)
     private Output<Map<String,String>> params;
 
     /**
-     * @return Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+     * @return Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
      * 
      */
     public Output<Map<String,String>> params() {
@@ -71,7 +71,7 @@ public final class ServiceTracingConfigArgs extends com.pulumi.resources.Resourc
         }
 
         /**
-         * @param params Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+         * @param params Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
          * 
          * @return builder
          * 
@@ -82,7 +82,7 @@ public final class ServiceTracingConfigArgs extends com.pulumi.resources.Resourc
         }
 
         /**
-         * @param params Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+         * @param params Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/inputs/V2FunctionState.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/inputs/V2FunctionState.java
@@ -25,184 +25,404 @@ public final class V2FunctionState extends com.pulumi.resources.ResourceArgs {
 
     public static final V2FunctionState Empty = new V2FunctionState();
 
+    /**
+     * The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     * 
+     */
     @Import(name="caPort")
     private @Nullable Output<Integer> caPort;
 
+    /**
+     * @return The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     * 
+     */
     public Optional<Output<Integer>> caPort() {
         return Optional.ofNullable(this.caPort);
     }
 
+    /**
+     * Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     * 
+     */
     @Import(name="code")
     private @Nullable Output<V2FunctionCodeArgs> code;
 
+    /**
+     * @return Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     * 
+     */
     public Optional<Output<V2FunctionCodeArgs>> code() {
         return Optional.ofNullable(this.code);
     }
 
+    /**
+     * crc64 of function code.
+     * 
+     */
     @Import(name="codeChecksum")
     private @Nullable Output<String> codeChecksum;
 
+    /**
+     * @return crc64 of function code.
+     * 
+     */
     public Optional<Output<String>> codeChecksum() {
         return Optional.ofNullable(this.codeChecksum);
     }
 
+    /**
+     * The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     * 
+     */
     @Import(name="cpu")
     private @Nullable Output<Double> cpu;
 
+    /**
+     * @return The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     * 
+     */
     public Optional<Output<Double>> cpu() {
         return Optional.ofNullable(this.cpu);
     }
 
+    /**
+     * create time of function.
+     * 
+     */
     @Import(name="createTime")
     private @Nullable Output<String> createTime;
 
+    /**
+     * @return create time of function.
+     * 
+     */
     public Optional<Output<String>> createTime() {
         return Optional.ofNullable(this.createTime);
     }
 
+    /**
+     * Custom-container runtime related function configuration. See `custom_container_config` below.
+     * 
+     */
     @Import(name="customContainerConfig")
     private @Nullable Output<V2FunctionCustomContainerConfigArgs> customContainerConfig;
 
+    /**
+     * @return Custom-container runtime related function configuration. See `custom_container_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomContainerConfigArgs>> customContainerConfig() {
         return Optional.ofNullable(this.customContainerConfig);
     }
 
+    /**
+     * Function custom DNS configuration. See `custom_dns` below.
+     * 
+     */
     @Import(name="customDns")
     private @Nullable Output<V2FunctionCustomDnsArgs> customDns;
 
+    /**
+     * @return Function custom DNS configuration. See `custom_dns` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomDnsArgs>> customDns() {
         return Optional.ofNullable(this.customDns);
     }
 
+    /**
+     * Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+     * 
+     */
     @Import(name="customHealthCheckConfig")
     private @Nullable Output<V2FunctionCustomHealthCheckConfigArgs> customHealthCheckConfig;
 
+    /**
+     * @return Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomHealthCheckConfigArgs>> customHealthCheckConfig() {
         return Optional.ofNullable(this.customHealthCheckConfig);
     }
 
+    /**
+     * Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+     * 
+     */
     @Import(name="customRuntimeConfig")
     private @Nullable Output<V2FunctionCustomRuntimeConfigArgs> customRuntimeConfig;
 
+    /**
+     * @return Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionCustomRuntimeConfigArgs>> customRuntimeConfig() {
         return Optional.ofNullable(this.customRuntimeConfig);
     }
 
+    /**
+     * description of function.
+     * 
+     */
     @Import(name="description")
     private @Nullable Output<String> description;
 
+    /**
+     * @return description of function.
+     * 
+     */
     public Optional<Output<String>> description() {
         return Optional.ofNullable(this.description);
     }
 
+    /**
+     * The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     * 
+     */
     @Import(name="diskSize")
     private @Nullable Output<Integer> diskSize;
 
+    /**
+     * @return The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     * 
+     */
     public Optional<Output<Integer>> diskSize() {
         return Optional.ofNullable(this.diskSize);
     }
 
+    /**
+     * The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     * 
+     */
     @Import(name="environmentVariables")
     private @Nullable Output<Map<String,String>> environmentVariables;
 
+    /**
+     * @return The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     * 
+     */
     public Optional<Output<Map<String,String>>> environmentVariables() {
         return Optional.ofNullable(this.environmentVariables);
     }
 
+    /**
+     * The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+     * 
+     */
     @Import(name="functionArn")
     private @Nullable Output<String> functionArn;
 
+    /**
+     * @return The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+     * 
+     */
     public Optional<Output<String>> functionArn() {
         return Optional.ofNullable(this.functionArn);
     }
 
+    /**
+     * function name.
+     * 
+     */
     @Import(name="functionName")
     private @Nullable Output<String> functionName;
 
+    /**
+     * @return function name.
+     * 
+     */
     public Optional<Output<String>> functionName() {
         return Optional.ofNullable(this.functionName);
     }
 
+    /**
+     * The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     * 
+     */
     @Import(name="gpuMemorySize")
     private @Nullable Output<Integer> gpuMemorySize;
 
+    /**
+     * @return The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     * 
+     */
     public Optional<Output<Integer>> gpuMemorySize() {
         return Optional.ofNullable(this.gpuMemorySize);
     }
 
+    /**
+     * entry point of function.
+     * 
+     */
     @Import(name="handler")
     private @Nullable Output<String> handler;
 
+    /**
+     * @return entry point of function.
+     * 
+     */
     public Optional<Output<String>> handler() {
         return Optional.ofNullable(this.handler);
     }
 
+    /**
+     * max running time of initializer.
+     * 
+     */
     @Import(name="initializationTimeout")
     private @Nullable Output<Integer> initializationTimeout;
 
+    /**
+     * @return max running time of initializer.
+     * 
+     */
     public Optional<Output<Integer>> initializationTimeout() {
         return Optional.ofNullable(this.initializationTimeout);
     }
 
+    /**
+     * initializer entry point of function.
+     * 
+     */
     @Import(name="initializer")
     private @Nullable Output<String> initializer;
 
+    /**
+     * @return initializer entry point of function.
+     * 
+     */
     public Optional<Output<String>> initializer() {
         return Optional.ofNullable(this.initializer);
     }
 
+    /**
+     * The maximum concurrency allowed for a single function instance.
+     * 
+     */
     @Import(name="instanceConcurrency")
     private @Nullable Output<Integer> instanceConcurrency;
 
+    /**
+     * @return The maximum concurrency allowed for a single function instance.
+     * 
+     */
     public Optional<Output<Integer>> instanceConcurrency() {
         return Optional.ofNullable(this.instanceConcurrency);
     }
 
+    /**
+     * Instance lifecycle configuration. See `instance_lifecycle_config` below.
+     * 
+     */
     @Import(name="instanceLifecycleConfig")
     private @Nullable Output<V2FunctionInstanceLifecycleConfigArgs> instanceLifecycleConfig;
 
+    /**
+     * @return Instance lifecycle configuration. See `instance_lifecycle_config` below.
+     * 
+     */
     public Optional<Output<V2FunctionInstanceLifecycleConfigArgs>> instanceLifecycleConfig() {
         return Optional.ofNullable(this.instanceLifecycleConfig);
     }
 
+    /**
+     * The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     * 
+     */
     @Import(name="instanceType")
     private @Nullable Output<String> instanceType;
 
+    /**
+     * @return The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     * 
+     */
     public Optional<Output<String>> instanceType() {
         return Optional.ofNullable(this.instanceType);
     }
 
+    /**
+     * List of layers.
+     * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     * 
+     */
     @Import(name="layers")
     private @Nullable Output<List<String>> layers;
 
+    /**
+     * @return List of layers.
+     * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     * 
+     */
     public Optional<Output<List<String>>> layers() {
         return Optional.ofNullable(this.layers);
     }
 
+    /**
+     * memory size needed by function.
+     * 
+     */
     @Import(name="memorySize")
     private @Nullable Output<Integer> memorySize;
 
+    /**
+     * @return memory size needed by function.
+     * 
+     */
     public Optional<Output<Integer>> memorySize() {
         return Optional.ofNullable(this.memorySize);
     }
 
+    /**
+     * runtime of function code.
+     * 
+     */
     @Import(name="runtime")
     private @Nullable Output<String> runtime;
 
+    /**
+     * @return runtime of function code.
+     * 
+     */
     public Optional<Output<String>> runtime() {
         return Optional.ofNullable(this.runtime);
     }
 
+    /**
+     * The name of the function Service.
+     * 
+     */
     @Import(name="serviceName")
     private @Nullable Output<String> serviceName;
 
+    /**
+     * @return The name of the function Service.
+     * 
+     */
     public Optional<Output<String>> serviceName() {
         return Optional.ofNullable(this.serviceName);
     }
 
+    /**
+     * max running time of function.
+     * 
+     */
     @Import(name="timeout")
     private @Nullable Output<Integer> timeout;
 
+    /**
+     * @return max running time of function.
+     * 
+     */
     public Optional<Output<Integer>> timeout() {
         return Optional.ofNullable(this.timeout);
     }
@@ -256,240 +476,571 @@ public final class V2FunctionState extends com.pulumi.resources.ResourceArgs {
             $ = new V2FunctionState(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @param caPort The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+         * 
+         * @return builder
+         * 
+         */
         public Builder caPort(@Nullable Output<Integer> caPort) {
             $.caPort = caPort;
             return this;
         }
 
+        /**
+         * @param caPort The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+         * 
+         * @return builder
+         * 
+         */
         public Builder caPort(Integer caPort) {
             return caPort(Output.of(caPort));
         }
 
+        /**
+         * @param code Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder code(@Nullable Output<V2FunctionCodeArgs> code) {
             $.code = code;
             return this;
         }
 
+        /**
+         * @param code Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder code(V2FunctionCodeArgs code) {
             return code(Output.of(code));
         }
 
+        /**
+         * @param codeChecksum crc64 of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder codeChecksum(@Nullable Output<String> codeChecksum) {
             $.codeChecksum = codeChecksum;
             return this;
         }
 
+        /**
+         * @param codeChecksum crc64 of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder codeChecksum(String codeChecksum) {
             return codeChecksum(Output.of(codeChecksum));
         }
 
+        /**
+         * @param cpu The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+         * 
+         * @return builder
+         * 
+         */
         public Builder cpu(@Nullable Output<Double> cpu) {
             $.cpu = cpu;
             return this;
         }
 
+        /**
+         * @param cpu The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+         * 
+         * @return builder
+         * 
+         */
         public Builder cpu(Double cpu) {
             return cpu(Output.of(cpu));
         }
 
+        /**
+         * @param createTime create time of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder createTime(@Nullable Output<String> createTime) {
             $.createTime = createTime;
             return this;
         }
 
+        /**
+         * @param createTime create time of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder createTime(String createTime) {
             return createTime(Output.of(createTime));
         }
 
+        /**
+         * @param customContainerConfig Custom-container runtime related function configuration. See `custom_container_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customContainerConfig(@Nullable Output<V2FunctionCustomContainerConfigArgs> customContainerConfig) {
             $.customContainerConfig = customContainerConfig;
             return this;
         }
 
+        /**
+         * @param customContainerConfig Custom-container runtime related function configuration. See `custom_container_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customContainerConfig(V2FunctionCustomContainerConfigArgs customContainerConfig) {
             return customContainerConfig(Output.of(customContainerConfig));
         }
 
+        /**
+         * @param customDns Function custom DNS configuration. See `custom_dns` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customDns(@Nullable Output<V2FunctionCustomDnsArgs> customDns) {
             $.customDns = customDns;
             return this;
         }
 
+        /**
+         * @param customDns Function custom DNS configuration. See `custom_dns` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customDns(V2FunctionCustomDnsArgs customDns) {
             return customDns(Output.of(customDns));
         }
 
+        /**
+         * @param customHealthCheckConfig Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customHealthCheckConfig(@Nullable Output<V2FunctionCustomHealthCheckConfigArgs> customHealthCheckConfig) {
             $.customHealthCheckConfig = customHealthCheckConfig;
             return this;
         }
 
+        /**
+         * @param customHealthCheckConfig Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customHealthCheckConfig(V2FunctionCustomHealthCheckConfigArgs customHealthCheckConfig) {
             return customHealthCheckConfig(Output.of(customHealthCheckConfig));
         }
 
+        /**
+         * @param customRuntimeConfig Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customRuntimeConfig(@Nullable Output<V2FunctionCustomRuntimeConfigArgs> customRuntimeConfig) {
             $.customRuntimeConfig = customRuntimeConfig;
             return this;
         }
 
+        /**
+         * @param customRuntimeConfig Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder customRuntimeConfig(V2FunctionCustomRuntimeConfigArgs customRuntimeConfig) {
             return customRuntimeConfig(Output.of(customRuntimeConfig));
         }
 
+        /**
+         * @param description description of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(@Nullable Output<String> description) {
             $.description = description;
             return this;
         }
 
+        /**
+         * @param description description of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder description(String description) {
             return description(Output.of(description));
         }
 
+        /**
+         * @param diskSize The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder diskSize(@Nullable Output<Integer> diskSize) {
             $.diskSize = diskSize;
             return this;
         }
 
+        /**
+         * @param diskSize The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder diskSize(Integer diskSize) {
             return diskSize(Output.of(diskSize));
         }
 
+        /**
+         * @param environmentVariables The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+         * 
+         * @return builder
+         * 
+         */
         public Builder environmentVariables(@Nullable Output<Map<String,String>> environmentVariables) {
             $.environmentVariables = environmentVariables;
             return this;
         }
 
+        /**
+         * @param environmentVariables The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+         * 
+         * @return builder
+         * 
+         */
         public Builder environmentVariables(Map<String,String> environmentVariables) {
             return environmentVariables(Output.of(environmentVariables));
         }
 
+        /**
+         * @param functionArn The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder functionArn(@Nullable Output<String> functionArn) {
             $.functionArn = functionArn;
             return this;
         }
 
+        /**
+         * @param functionArn The Function Compute service function arn. It formats as `acs:fc:&lt;region&gt;:&lt;uid&gt;:services/&lt;serviceName&gt;.LATEST/functions/&lt;functionName&gt;`.
+         * 
+         * @return builder
+         * 
+         */
         public Builder functionArn(String functionArn) {
             return functionArn(Output.of(functionArn));
         }
 
+        /**
+         * @param functionName function name.
+         * 
+         * @return builder
+         * 
+         */
         public Builder functionName(@Nullable Output<String> functionName) {
             $.functionName = functionName;
             return this;
         }
 
+        /**
+         * @param functionName function name.
+         * 
+         * @return builder
+         * 
+         */
         public Builder functionName(String functionName) {
             return functionName(Output.of(functionName));
         }
 
+        /**
+         * @param gpuMemorySize The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder gpuMemorySize(@Nullable Output<Integer> gpuMemorySize) {
             $.gpuMemorySize = gpuMemorySize;
             return this;
         }
 
+        /**
+         * @param gpuMemorySize The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+         * 
+         * @return builder
+         * 
+         */
         public Builder gpuMemorySize(Integer gpuMemorySize) {
             return gpuMemorySize(Output.of(gpuMemorySize));
         }
 
+        /**
+         * @param handler entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder handler(@Nullable Output<String> handler) {
             $.handler = handler;
             return this;
         }
 
+        /**
+         * @param handler entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder handler(String handler) {
             return handler(Output.of(handler));
         }
 
+        /**
+         * @param initializationTimeout max running time of initializer.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializationTimeout(@Nullable Output<Integer> initializationTimeout) {
             $.initializationTimeout = initializationTimeout;
             return this;
         }
 
+        /**
+         * @param initializationTimeout max running time of initializer.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializationTimeout(Integer initializationTimeout) {
             return initializationTimeout(Output.of(initializationTimeout));
         }
 
+        /**
+         * @param initializer initializer entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializer(@Nullable Output<String> initializer) {
             $.initializer = initializer;
             return this;
         }
 
+        /**
+         * @param initializer initializer entry point of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder initializer(String initializer) {
             return initializer(Output.of(initializer));
         }
 
+        /**
+         * @param instanceConcurrency The maximum concurrency allowed for a single function instance.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceConcurrency(@Nullable Output<Integer> instanceConcurrency) {
             $.instanceConcurrency = instanceConcurrency;
             return this;
         }
 
+        /**
+         * @param instanceConcurrency The maximum concurrency allowed for a single function instance.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceConcurrency(Integer instanceConcurrency) {
             return instanceConcurrency(Output.of(instanceConcurrency));
         }
 
+        /**
+         * @param instanceLifecycleConfig Instance lifecycle configuration. See `instance_lifecycle_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceLifecycleConfig(@Nullable Output<V2FunctionInstanceLifecycleConfigArgs> instanceLifecycleConfig) {
             $.instanceLifecycleConfig = instanceLifecycleConfig;
             return this;
         }
 
+        /**
+         * @param instanceLifecycleConfig Instance lifecycle configuration. See `instance_lifecycle_config` below.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceLifecycleConfig(V2FunctionInstanceLifecycleConfigArgs instanceLifecycleConfig) {
             return instanceLifecycleConfig(Output.of(instanceLifecycleConfig));
         }
 
+        /**
+         * @param instanceType The instance type of the function. Valid values:
+         * - **e1**: Elastic instance.
+         * - **c1**: performance instance.
+         * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+         * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+         * - **g1**: Same as **fc.gpu.tesla.1**.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceType(@Nullable Output<String> instanceType) {
             $.instanceType = instanceType;
             return this;
         }
 
+        /**
+         * @param instanceType The instance type of the function. Valid values:
+         * - **e1**: Elastic instance.
+         * - **c1**: performance instance.
+         * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+         * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+         * - **g1**: Same as **fc.gpu.tesla.1**.
+         * 
+         * @return builder
+         * 
+         */
         public Builder instanceType(String instanceType) {
             return instanceType(Output.of(instanceType));
         }
 
+        /**
+         * @param layers List of layers.
+         * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+         * 
+         * @return builder
+         * 
+         */
         public Builder layers(@Nullable Output<List<String>> layers) {
             $.layers = layers;
             return this;
         }
 
+        /**
+         * @param layers List of layers.
+         * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+         * 
+         * @return builder
+         * 
+         */
         public Builder layers(List<String> layers) {
             return layers(Output.of(layers));
         }
 
+        /**
+         * @param layers List of layers.
+         * &gt; **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+         * 
+         * @return builder
+         * 
+         */
         public Builder layers(String... layers) {
             return layers(List.of(layers));
         }
 
+        /**
+         * @param memorySize memory size needed by function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder memorySize(@Nullable Output<Integer> memorySize) {
             $.memorySize = memorySize;
             return this;
         }
 
+        /**
+         * @param memorySize memory size needed by function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder memorySize(Integer memorySize) {
             return memorySize(Output.of(memorySize));
         }
 
+        /**
+         * @param runtime runtime of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder runtime(@Nullable Output<String> runtime) {
             $.runtime = runtime;
             return this;
         }
 
+        /**
+         * @param runtime runtime of function code.
+         * 
+         * @return builder
+         * 
+         */
         public Builder runtime(String runtime) {
             return runtime(Output.of(runtime));
         }
 
+        /**
+         * @param serviceName The name of the function Service.
+         * 
+         * @return builder
+         * 
+         */
         public Builder serviceName(@Nullable Output<String> serviceName) {
             $.serviceName = serviceName;
             return this;
         }
 
+        /**
+         * @param serviceName The name of the function Service.
+         * 
+         * @return builder
+         * 
+         */
         public Builder serviceName(String serviceName) {
             return serviceName(Output.of(serviceName));
         }
 
+        /**
+         * @param timeout max running time of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder timeout(@Nullable Output<Integer> timeout) {
             $.timeout = timeout;
             return this;
         }
 
+        /**
+         * @param timeout max running time of function.
+         * 
+         * @return builder
+         * 
+         */
         public Builder timeout(Integer timeout) {
             return timeout(Output.of(timeout));
         }

--- a/sdk/java/src/main/java/com/pulumi/alicloud/fc/outputs/ServiceTracingConfig.java
+++ b/sdk/java/src/main/java/com/pulumi/alicloud/fc/outputs/ServiceTracingConfig.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 @CustomType
 public final class ServiceTracingConfig {
     /**
-     * @return Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+     * @return Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
      * 
      */
     private Map<String,String> params;
@@ -24,7 +24,7 @@ public final class ServiceTracingConfig {
 
     private ServiceTracingConfig() {}
     /**
-     * @return Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+     * @return Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is &#34;endpoint&#34; and the value is your tracing intranet endpoint. For example endpoint: &lt;http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces&gt;.
      * 
      */
     public Map<String,String> params() {

--- a/sdk/nodejs/fc/getService.ts
+++ b/sdk/nodejs/fc/getService.ts
@@ -10,17 +10,6 @@ import * as utilities from "../utilities";
  * For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
  *
  * > **NOTE:** Available since v1.112.0+
- *
- * ## Example Usage
- *
- * ```typescript
- * import * as pulumi from "@pulumi/pulumi";
- * import * as alicloud from "@pulumi/alicloud";
- *
- * const open = alicloud.fc.getService({
- *     enable: "On",
- * });
- * ```
  */
 export function getService(args?: GetServiceArgs, opts?: pulumi.InvokeOptions): Promise<GetServiceResult> {
     args = args || {};
@@ -62,17 +51,6 @@ export interface GetServiceResult {
  * For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
  *
  * > **NOTE:** Available since v1.112.0+
- *
- * ## Example Usage
- *
- * ```typescript
- * import * as pulumi from "@pulumi/pulumi";
- * import * as alicloud from "@pulumi/alicloud";
- *
- * const open = alicloud.fc.getService({
- *     enable: "On",
- * });
- * ```
  */
 export function getServiceOutput(args?: GetServiceOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetServiceResult> {
     args = args || {};

--- a/sdk/nodejs/fc/service.ts
+++ b/sdk/nodejs/fc/service.ts
@@ -6,6 +6,31 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
+/**
+ * Provides a Alicloud Function Compute Service resource. The resource is the base of launching Function and Trigger configuration.
+ * For information about Service and how to use it, see [What is Function Compute](https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-createservice).
+ *
+ * > **NOTE:** The resource requires a provider field 'account_id'. See account_id.
+ *
+ * > **NOTE:** If you happen the error "Argument 'internetAccess' is not supported", you need to log on web console and click button "Apply VPC Function"
+ * which is in the upper of [Function Service Web Console](https://fc.console.aliyun.com/) page.
+ *
+ * > **NOTE:** Currently not all regions support Function Compute Service.
+ * For more details supported regions, see [Service endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm)
+ *
+ * > **NOTE:** Available since v1.93.0.
+ * ## Module Support
+ *
+ * You can use to the existing fc module to create a service and a function quickly and then set several triggers for it.
+ *
+ * ## Import
+ *
+ * Function Compute Service can be imported using the id or name, e.g.
+ *
+ * ```sh
+ * $ pulumi import alicloud:fc/service:Service foo my-fc-service
+ * ```
+ */
 export class Service extends pulumi.CustomResource {
     /**
      * Get an existing Service resource's state with the given name, ID, and optional extra
@@ -34,19 +59,61 @@ export class Service extends pulumi.CustomResource {
         return obj['__pulumiType'] === Service.__pulumiType;
     }
 
+    /**
+     * The Function Compute Service description.
+     */
     public readonly description!: pulumi.Output<string | undefined>;
+    /**
+     * Whether to allow the Service to access Internet. Default to "true".
+     */
     public readonly internetAccess!: pulumi.Output<boolean | undefined>;
+    /**
+     * The date this resource was last modified.
+     */
     public /*out*/ readonly lastModified!: pulumi.Output<string>;
+    /**
+     * Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+     */
     public readonly logConfig!: pulumi.Output<outputs.fc.ServiceLogConfig | undefined>;
+    /**
+     * The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+     */
     public readonly name!: pulumi.Output<string>;
+    /**
+     * Setting a prefix to get a only name. It is conflict with `name`.
+     */
     public readonly namePrefix!: pulumi.Output<string | undefined>;
+    /**
+     * Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+     */
     public readonly nasConfig!: pulumi.Output<outputs.fc.ServiceNasConfig | undefined>;
+    /**
+     * Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     */
     public readonly publish!: pulumi.Output<boolean | undefined>;
+    /**
+     * RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     */
     public readonly role!: pulumi.Output<string | undefined>;
+    /**
+     * The Function Compute Service ID.
+     */
     public /*out*/ readonly serviceId!: pulumi.Output<string>;
+    /**
+     * Map for tagging resources.
+     */
     public readonly tags!: pulumi.Output<{[key: string]: string} | undefined>;
+    /**
+     * Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+     */
     public readonly tracingConfig!: pulumi.Output<outputs.fc.ServiceTracingConfig | undefined>;
+    /**
+     * The latest published version of your Function Compute Service.
+     */
     public /*out*/ readonly version!: pulumi.Output<string>;
+    /**
+     * Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+     */
     public readonly vpcConfig!: pulumi.Output<outputs.fc.ServiceVpcConfig | undefined>;
 
     /**
@@ -98,20 +165,65 @@ export class Service extends pulumi.CustomResource {
     }
 }
 
+/**
+ * Input properties used for looking up and filtering Service resources.
+ */
 export interface ServiceState {
+    /**
+     * The Function Compute Service description.
+     */
     description?: pulumi.Input<string>;
+    /**
+     * Whether to allow the Service to access Internet. Default to "true".
+     */
     internetAccess?: pulumi.Input<boolean>;
+    /**
+     * The date this resource was last modified.
+     */
     lastModified?: pulumi.Input<string>;
+    /**
+     * Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+     */
     logConfig?: pulumi.Input<inputs.fc.ServiceLogConfig>;
+    /**
+     * The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+     */
     name?: pulumi.Input<string>;
+    /**
+     * Setting a prefix to get a only name. It is conflict with `name`.
+     */
     namePrefix?: pulumi.Input<string>;
+    /**
+     * Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+     */
     nasConfig?: pulumi.Input<inputs.fc.ServiceNasConfig>;
+    /**
+     * Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     */
     publish?: pulumi.Input<boolean>;
+    /**
+     * RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     */
     role?: pulumi.Input<string>;
+    /**
+     * The Function Compute Service ID.
+     */
     serviceId?: pulumi.Input<string>;
+    /**
+     * Map for tagging resources.
+     */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
+     * Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+     */
     tracingConfig?: pulumi.Input<inputs.fc.ServiceTracingConfig>;
+    /**
+     * The latest published version of your Function Compute Service.
+     */
     version?: pulumi.Input<string>;
+    /**
+     * Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+     */
     vpcConfig?: pulumi.Input<inputs.fc.ServiceVpcConfig>;
 }
 
@@ -119,15 +231,48 @@ export interface ServiceState {
  * The set of arguments for constructing a Service resource.
  */
 export interface ServiceArgs {
+    /**
+     * The Function Compute Service description.
+     */
     description?: pulumi.Input<string>;
+    /**
+     * Whether to allow the Service to access Internet. Default to "true".
+     */
     internetAccess?: pulumi.Input<boolean>;
+    /**
+     * Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `logConfig` requires the following: (**NOTE:** If both `project` and `logstore` are empty, logConfig is considered to be empty or unset.). See `logConfig` below.
+     */
     logConfig?: pulumi.Input<inputs.fc.ServiceLogConfig>;
+    /**
+     * The Function Compute Service name. It is the only in one Alicloud account and is conflict with `namePrefix`.
+     */
     name?: pulumi.Input<string>;
+    /**
+     * Setting a prefix to get a only name. It is conflict with `name`.
+     */
     namePrefix?: pulumi.Input<string>;
+    /**
+     * Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nasConfig` below.
+     */
     nasConfig?: pulumi.Input<inputs.fc.ServiceNasConfig>;
+    /**
+     * Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+     */
     publish?: pulumi.Input<boolean>;
+    /**
+     * RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+     */
     role?: pulumi.Input<string>;
+    /**
+     * Map for tagging resources.
+     */
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
+     * Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracingConfig` requires the following: (**NOTE:** If both `type` and `params` are empty, tracingConfig is considered to be empty or unset.). See `tracingConfig` below.
+     */
     tracingConfig?: pulumi.Input<inputs.fc.ServiceTracingConfig>;
+    /**
+     * Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpcConfig` requires the following: (**NOTE:** If both `vswitchIds` and `securityGroupId` are empty, vpcConfig is considered to be empty or unset.). See `vpcConfig` below.
+     */
     vpcConfig?: pulumi.Input<inputs.fc.ServiceVpcConfig>;
 }

--- a/sdk/nodejs/fc/v2function.ts
+++ b/sdk/nodejs/fc/v2function.ts
@@ -6,6 +6,21 @@ import * as inputs from "../types/input";
 import * as outputs from "../types/output";
 import * as utilities from "../utilities";
 
+/**
+ * Provides a FCV2 Function resource. Function is the unit of system scheduling and operation. Functions must be subordinate to services. All functions under the same service share some identical settings, such as service authorization and log configuration.
+ *
+ * For information about FCV2 Function and how to use it, see [What is Function](https://www.alibabacloud.com/help/en/resource-orchestration-service/latest/aliyun-fc-function).
+ *
+ * > **NOTE:** Available since v1.208.0.
+ *
+ * ## Import
+ *
+ * FCV2 Function can be imported using the id, e.g.
+ *
+ * ```sh
+ * $ pulumi import alicloud:fc/v2Function:V2Function example <service_name>:<function_name>
+ * ```
+ */
 export class V2Function extends pulumi.CustomResource {
     /**
      * Get an existing V2Function resource's state with the given name, ID, and optional extra
@@ -34,31 +49,115 @@ export class V2Function extends pulumi.CustomResource {
         return obj['__pulumiType'] === V2Function.__pulumiType;
     }
 
+    /**
+     * The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     */
     public readonly caPort!: pulumi.Output<number>;
+    /**
+     * Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     */
     public readonly code!: pulumi.Output<outputs.fc.V2FunctionCode | undefined>;
+    /**
+     * crc64 of function code.
+     */
     public readonly codeChecksum!: pulumi.Output<string>;
+    /**
+     * The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     */
     public readonly cpu!: pulumi.Output<number | undefined>;
+    /**
+     * create time of function.
+     */
     public /*out*/ readonly createTime!: pulumi.Output<string>;
+    /**
+     * Custom-container runtime related function configuration. See `customContainerConfig` below.
+     */
     public readonly customContainerConfig!: pulumi.Output<outputs.fc.V2FunctionCustomContainerConfig | undefined>;
+    /**
+     * Function custom DNS configuration. See `customDns` below.
+     */
     public readonly customDns!: pulumi.Output<outputs.fc.V2FunctionCustomDns | undefined>;
+    /**
+     * Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
+     */
     public readonly customHealthCheckConfig!: pulumi.Output<outputs.fc.V2FunctionCustomHealthCheckConfig | undefined>;
+    /**
+     * Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+     */
     public readonly customRuntimeConfig!: pulumi.Output<outputs.fc.V2FunctionCustomRuntimeConfig | undefined>;
+    /**
+     * description of function.
+     */
     public readonly description!: pulumi.Output<string | undefined>;
+    /**
+     * The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     */
     public readonly diskSize!: pulumi.Output<number | undefined>;
+    /**
+     * The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     */
     public readonly environmentVariables!: pulumi.Output<{[key: string]: string} | undefined>;
+    /**
+     * The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+     */
     public /*out*/ readonly functionArn!: pulumi.Output<string>;
+    /**
+     * function name.
+     */
     public readonly functionName!: pulumi.Output<string>;
+    /**
+     * The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     */
     public readonly gpuMemorySize!: pulumi.Output<number | undefined>;
+    /**
+     * entry point of function.
+     */
     public readonly handler!: pulumi.Output<string>;
+    /**
+     * max running time of initializer.
+     */
     public readonly initializationTimeout!: pulumi.Output<number>;
+    /**
+     * initializer entry point of function.
+     */
     public readonly initializer!: pulumi.Output<string | undefined>;
+    /**
+     * The maximum concurrency allowed for a single function instance.
+     */
     public readonly instanceConcurrency!: pulumi.Output<number>;
+    /**
+     * Instance lifecycle configuration. See `instanceLifecycleConfig` below.
+     */
     public readonly instanceLifecycleConfig!: pulumi.Output<outputs.fc.V2FunctionInstanceLifecycleConfig | undefined>;
+    /**
+     * The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     */
     public readonly instanceType!: pulumi.Output<string>;
+    /**
+     * List of layers.
+     * > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     */
     public readonly layers!: pulumi.Output<string[] | undefined>;
+    /**
+     * memory size needed by function.
+     */
     public readonly memorySize!: pulumi.Output<number>;
+    /**
+     * runtime of function code.
+     */
     public readonly runtime!: pulumi.Output<string>;
+    /**
+     * The name of the function Service.
+     */
     public readonly serviceName!: pulumi.Output<string>;
+    /**
+     * max running time of function.
+     */
     public readonly timeout!: pulumi.Output<number>;
 
     /**
@@ -146,32 +245,119 @@ export class V2Function extends pulumi.CustomResource {
     }
 }
 
+/**
+ * Input properties used for looking up and filtering V2Function resources.
+ */
 export interface V2FunctionState {
+    /**
+     * The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     */
     caPort?: pulumi.Input<number>;
+    /**
+     * Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     */
     code?: pulumi.Input<inputs.fc.V2FunctionCode>;
+    /**
+     * crc64 of function code.
+     */
     codeChecksum?: pulumi.Input<string>;
+    /**
+     * The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     */
     cpu?: pulumi.Input<number>;
+    /**
+     * create time of function.
+     */
     createTime?: pulumi.Input<string>;
+    /**
+     * Custom-container runtime related function configuration. See `customContainerConfig` below.
+     */
     customContainerConfig?: pulumi.Input<inputs.fc.V2FunctionCustomContainerConfig>;
+    /**
+     * Function custom DNS configuration. See `customDns` below.
+     */
     customDns?: pulumi.Input<inputs.fc.V2FunctionCustomDns>;
+    /**
+     * Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
+     */
     customHealthCheckConfig?: pulumi.Input<inputs.fc.V2FunctionCustomHealthCheckConfig>;
+    /**
+     * Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+     */
     customRuntimeConfig?: pulumi.Input<inputs.fc.V2FunctionCustomRuntimeConfig>;
+    /**
+     * description of function.
+     */
     description?: pulumi.Input<string>;
+    /**
+     * The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     */
     diskSize?: pulumi.Input<number>;
+    /**
+     * The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     */
     environmentVariables?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
+     * The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+     */
     functionArn?: pulumi.Input<string>;
+    /**
+     * function name.
+     */
     functionName?: pulumi.Input<string>;
+    /**
+     * The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     */
     gpuMemorySize?: pulumi.Input<number>;
+    /**
+     * entry point of function.
+     */
     handler?: pulumi.Input<string>;
+    /**
+     * max running time of initializer.
+     */
     initializationTimeout?: pulumi.Input<number>;
+    /**
+     * initializer entry point of function.
+     */
     initializer?: pulumi.Input<string>;
+    /**
+     * The maximum concurrency allowed for a single function instance.
+     */
     instanceConcurrency?: pulumi.Input<number>;
+    /**
+     * Instance lifecycle configuration. See `instanceLifecycleConfig` below.
+     */
     instanceLifecycleConfig?: pulumi.Input<inputs.fc.V2FunctionInstanceLifecycleConfig>;
+    /**
+     * The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     */
     instanceType?: pulumi.Input<string>;
+    /**
+     * List of layers.
+     * > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     */
     layers?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * memory size needed by function.
+     */
     memorySize?: pulumi.Input<number>;
+    /**
+     * runtime of function code.
+     */
     runtime?: pulumi.Input<string>;
+    /**
+     * The name of the function Service.
+     */
     serviceName?: pulumi.Input<string>;
+    /**
+     * max running time of function.
+     */
     timeout?: pulumi.Input<number>;
 }
 
@@ -179,28 +365,106 @@ export interface V2FunctionState {
  * The set of arguments for constructing a V2Function resource.
  */
 export interface V2FunctionArgs {
+    /**
+     * The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+     */
     caPort?: pulumi.Input<number>;
+    /**
+     * Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+     */
     code?: pulumi.Input<inputs.fc.V2FunctionCode>;
+    /**
+     * crc64 of function code.
+     */
     codeChecksum?: pulumi.Input<string>;
+    /**
+     * The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+     */
     cpu?: pulumi.Input<number>;
+    /**
+     * Custom-container runtime related function configuration. See `customContainerConfig` below.
+     */
     customContainerConfig?: pulumi.Input<inputs.fc.V2FunctionCustomContainerConfig>;
+    /**
+     * Function custom DNS configuration. See `customDns` below.
+     */
     customDns?: pulumi.Input<inputs.fc.V2FunctionCustomDns>;
+    /**
+     * Custom runtime/container Custom health check configuration. See `customHealthCheckConfig` below.
+     */
     customHealthCheckConfig?: pulumi.Input<inputs.fc.V2FunctionCustomHealthCheckConfig>;
+    /**
+     * Detailed configuration of Custom Runtime function. See `customRuntimeConfig` below.
+     */
     customRuntimeConfig?: pulumi.Input<inputs.fc.V2FunctionCustomRuntimeConfig>;
+    /**
+     * description of function.
+     */
     description?: pulumi.Input<string>;
+    /**
+     * The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+     */
     diskSize?: pulumi.Input<number>;
+    /**
+     * The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+     */
     environmentVariables?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
+    /**
+     * function name.
+     */
     functionName: pulumi.Input<string>;
+    /**
+     * The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+     */
     gpuMemorySize?: pulumi.Input<number>;
+    /**
+     * entry point of function.
+     */
     handler: pulumi.Input<string>;
+    /**
+     * max running time of initializer.
+     */
     initializationTimeout?: pulumi.Input<number>;
+    /**
+     * initializer entry point of function.
+     */
     initializer?: pulumi.Input<string>;
+    /**
+     * The maximum concurrency allowed for a single function instance.
+     */
     instanceConcurrency?: pulumi.Input<number>;
+    /**
+     * Instance lifecycle configuration. See `instanceLifecycleConfig` below.
+     */
     instanceLifecycleConfig?: pulumi.Input<inputs.fc.V2FunctionInstanceLifecycleConfig>;
+    /**
+     * The instance type of the function. Valid values:
+     * - **e1**: Elastic instance.
+     * - **c1**: performance instance.
+     * - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+     * - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+     * - **g1**: Same as **fc.gpu.tesla.1**.
+     */
     instanceType?: pulumi.Input<string>;
+    /**
+     * List of layers.
+     * > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+     */
     layers?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * memory size needed by function.
+     */
     memorySize?: pulumi.Input<number>;
+    /**
+     * runtime of function code.
+     */
     runtime: pulumi.Input<string>;
+    /**
+     * The name of the function Service.
+     */
     serviceName: pulumi.Input<string>;
+    /**
+     * max running time of function.
+     */
     timeout?: pulumi.Input<number>;
 }

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -11520,7 +11520,7 @@ export namespace fc {
 
     export interface ServiceTracingConfig {
         /**
-         * Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+         * Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
          */
         params: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
         /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -34136,7 +34136,7 @@ export namespace fc {
 
     export interface ServiceTracingConfig {
         /**
-         * Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+         * Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
          */
         params: {[key: string]: string};
         /**

--- a/sdk/python/pulumi_alicloud/fc/_inputs.py
+++ b/sdk/python/pulumi_alicloud/fc/_inputs.py
@@ -741,7 +741,7 @@ if not MYPY:
     class ServiceTracingConfigArgsDict(TypedDict):
         params: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]
         """
-        Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
         """
         type: pulumi.Input[_builtins.str]
         """
@@ -756,7 +756,7 @@ class ServiceTracingConfigArgs:
                  params: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
                  type: pulumi.Input[_builtins.str]):
         """
-        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] params: Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] params: Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
         :param pulumi.Input[_builtins.str] type: Tracing protocol type. Currently, only Jaeger is supported.
         """
         pulumi.set(__self__, "params", params)
@@ -766,7 +766,7 @@ class ServiceTracingConfigArgs:
     @pulumi.getter
     def params(self) -> pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]:
         """
-        Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
         """
         return pulumi.get(self, "params")
 

--- a/sdk/python/pulumi_alicloud/fc/get_service.py
+++ b/sdk/python/pulumi_alicloud/fc/get_service.py
@@ -79,15 +79,6 @@ def get_service(enable: Optional[_builtins.str] = None,
 
     > **NOTE:** Available since v1.112.0+
 
-    ## Example Usage
-
-    ```python
-    import pulumi
-    import pulumi_alicloud as alicloud
-
-    open = alicloud.fc.get_service(enable="On")
-    ```
-
 
     :param _builtins.str enable: Setting the value to `On` to enable the service. If has been enabled, return the result. Valid values: `On` or `Off`. Default to `Off`.
            
@@ -110,15 +101,6 @@ def get_service_output(enable: Optional[pulumi.Input[Optional[_builtins.str]]] =
     For information about FC and how to use it, see [What is FC](https://www.alibabacloud.com/help/en/product/50980.htm).
 
     > **NOTE:** Available since v1.112.0+
-
-    ## Example Usage
-
-    ```python
-    import pulumi
-    import pulumi_alicloud as alicloud
-
-    open = alicloud.fc.get_service(enable="On")
-    ```
 
 
     :param _builtins.str enable: Setting the value to `On` to enable the service. If has been enabled, return the result. Valid values: `On` or `Off`. Default to `Off`.

--- a/sdk/python/pulumi_alicloud/fc/outputs.py
+++ b/sdk/python/pulumi_alicloud/fc/outputs.py
@@ -582,7 +582,7 @@ class ServiceTracingConfig(dict):
                  params: Mapping[str, _builtins.str],
                  type: _builtins.str):
         """
-        :param Mapping[str, _builtins.str] params: Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        :param Mapping[str, _builtins.str] params: Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
         :param _builtins.str type: Tracing protocol type. Currently, only Jaeger is supported.
         """
         pulumi.set(__self__, "params", params)
@@ -592,7 +592,7 @@ class ServiceTracingConfig(dict):
     @pulumi.getter
     def params(self) -> Mapping[str, _builtins.str]:
         """
-        Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces.
+        Tracing parameters, which type is map[string]string. When the protocol type is Jaeger, the key is "endpoint" and the value is your tracing intranet endpoint. For example endpoint: <http://tracing-analysis-dc-hz.aliyuncs.com/adapt_xxx/api/traces>.
         """
         return pulumi.get(self, "params")
 

--- a/sdk/python/pulumi_alicloud/fc/service.py
+++ b/sdk/python/pulumi_alicloud/fc/service.py
@@ -34,6 +34,17 @@ class ServiceArgs:
                  vpc_config: Optional[pulumi.Input['ServiceVpcConfigArgs']] = None):
         """
         The set of arguments for constructing a Service resource.
+        :param pulumi.Input[_builtins.str] description: The Function Compute Service description.
+        :param pulumi.Input[_builtins.bool] internet_access: Whether to allow the Service to access Internet. Default to "true".
+        :param pulumi.Input['ServiceLogConfigArgs'] log_config: Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        :param pulumi.Input[_builtins.str] name: The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        :param pulumi.Input[_builtins.str] name_prefix: Setting a prefix to get a only name. It is conflict with `name`.
+        :param pulumi.Input['ServiceNasConfigArgs'] nas_config: Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        :param pulumi.Input[_builtins.bool] publish: Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        :param pulumi.Input[_builtins.str] role: RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Map for tagging resources.
+        :param pulumi.Input['ServiceTracingConfigArgs'] tracing_config: Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        :param pulumi.Input['ServiceVpcConfigArgs'] vpc_config: Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
         """
         if description is not None:
             pulumi.set(__self__, "description", description)
@@ -61,6 +72,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Function Compute Service description.
+        """
         return pulumi.get(self, "description")
 
     @description.setter
@@ -70,6 +84,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter(name="internetAccess")
     def internet_access(self) -> Optional[pulumi.Input[_builtins.bool]]:
+        """
+        Whether to allow the Service to access Internet. Default to "true".
+        """
         return pulumi.get(self, "internet_access")
 
     @internet_access.setter
@@ -79,6 +96,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter(name="logConfig")
     def log_config(self) -> Optional[pulumi.Input['ServiceLogConfigArgs']]:
+        """
+        Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        """
         return pulumi.get(self, "log_config")
 
     @log_config.setter
@@ -88,6 +108,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        """
         return pulumi.get(self, "name")
 
     @name.setter
@@ -97,6 +120,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter(name="namePrefix")
     def name_prefix(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        Setting a prefix to get a only name. It is conflict with `name`.
+        """
         return pulumi.get(self, "name_prefix")
 
     @name_prefix.setter
@@ -106,6 +132,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter(name="nasConfig")
     def nas_config(self) -> Optional[pulumi.Input['ServiceNasConfigArgs']]:
+        """
+        Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        """
         return pulumi.get(self, "nas_config")
 
     @nas_config.setter
@@ -115,6 +144,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter
     def publish(self) -> Optional[pulumi.Input[_builtins.bool]]:
+        """
+        Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        """
         return pulumi.get(self, "publish")
 
     @publish.setter
@@ -124,6 +156,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter
     def role(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        """
         return pulumi.get(self, "role")
 
     @role.setter
@@ -133,6 +168,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter
     def tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]:
+        """
+        Map for tagging resources.
+        """
         return pulumi.get(self, "tags")
 
     @tags.setter
@@ -142,6 +180,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter(name="tracingConfig")
     def tracing_config(self) -> Optional[pulumi.Input['ServiceTracingConfigArgs']]:
+        """
+        Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        """
         return pulumi.get(self, "tracing_config")
 
     @tracing_config.setter
@@ -151,6 +192,9 @@ class ServiceArgs:
     @_builtins.property
     @pulumi.getter(name="vpcConfig")
     def vpc_config(self) -> Optional[pulumi.Input['ServiceVpcConfigArgs']]:
+        """
+        Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+        """
         return pulumi.get(self, "vpc_config")
 
     @vpc_config.setter
@@ -177,6 +221,20 @@ class _ServiceState:
                  vpc_config: Optional[pulumi.Input['ServiceVpcConfigArgs']] = None):
         """
         Input properties used for looking up and filtering Service resources.
+        :param pulumi.Input[_builtins.str] description: The Function Compute Service description.
+        :param pulumi.Input[_builtins.bool] internet_access: Whether to allow the Service to access Internet. Default to "true".
+        :param pulumi.Input[_builtins.str] last_modified: The date this resource was last modified.
+        :param pulumi.Input['ServiceLogConfigArgs'] log_config: Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        :param pulumi.Input[_builtins.str] name: The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        :param pulumi.Input[_builtins.str] name_prefix: Setting a prefix to get a only name. It is conflict with `name`.
+        :param pulumi.Input['ServiceNasConfigArgs'] nas_config: Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        :param pulumi.Input[_builtins.bool] publish: Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        :param pulumi.Input[_builtins.str] role: RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        :param pulumi.Input[_builtins.str] service_id: The Function Compute Service ID.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Map for tagging resources.
+        :param pulumi.Input['ServiceTracingConfigArgs'] tracing_config: Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        :param pulumi.Input[_builtins.str] version: The latest published version of your Function Compute Service.
+        :param pulumi.Input['ServiceVpcConfigArgs'] vpc_config: Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
         """
         if description is not None:
             pulumi.set(__self__, "description", description)
@@ -210,6 +268,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Function Compute Service description.
+        """
         return pulumi.get(self, "description")
 
     @description.setter
@@ -219,6 +280,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="internetAccess")
     def internet_access(self) -> Optional[pulumi.Input[_builtins.bool]]:
+        """
+        Whether to allow the Service to access Internet. Default to "true".
+        """
         return pulumi.get(self, "internet_access")
 
     @internet_access.setter
@@ -228,6 +292,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="lastModified")
     def last_modified(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The date this resource was last modified.
+        """
         return pulumi.get(self, "last_modified")
 
     @last_modified.setter
@@ -237,6 +304,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="logConfig")
     def log_config(self) -> Optional[pulumi.Input['ServiceLogConfigArgs']]:
+        """
+        Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        """
         return pulumi.get(self, "log_config")
 
     @log_config.setter
@@ -246,6 +316,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter
     def name(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        """
         return pulumi.get(self, "name")
 
     @name.setter
@@ -255,6 +328,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="namePrefix")
     def name_prefix(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        Setting a prefix to get a only name. It is conflict with `name`.
+        """
         return pulumi.get(self, "name_prefix")
 
     @name_prefix.setter
@@ -264,6 +340,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="nasConfig")
     def nas_config(self) -> Optional[pulumi.Input['ServiceNasConfigArgs']]:
+        """
+        Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        """
         return pulumi.get(self, "nas_config")
 
     @nas_config.setter
@@ -273,6 +352,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter
     def publish(self) -> Optional[pulumi.Input[_builtins.bool]]:
+        """
+        Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        """
         return pulumi.get(self, "publish")
 
     @publish.setter
@@ -282,6 +364,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter
     def role(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        """
         return pulumi.get(self, "role")
 
     @role.setter
@@ -291,6 +376,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="serviceId")
     def service_id(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Function Compute Service ID.
+        """
         return pulumi.get(self, "service_id")
 
     @service_id.setter
@@ -300,6 +388,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter
     def tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]:
+        """
+        Map for tagging resources.
+        """
         return pulumi.get(self, "tags")
 
     @tags.setter
@@ -309,6 +400,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="tracingConfig")
     def tracing_config(self) -> Optional[pulumi.Input['ServiceTracingConfigArgs']]:
+        """
+        Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        """
         return pulumi.get(self, "tracing_config")
 
     @tracing_config.setter
@@ -318,6 +412,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter
     def version(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The latest published version of your Function Compute Service.
+        """
         return pulumi.get(self, "version")
 
     @version.setter
@@ -327,6 +424,9 @@ class _ServiceState:
     @_builtins.property
     @pulumi.getter(name="vpcConfig")
     def vpc_config(self) -> Optional[pulumi.Input['ServiceVpcConfigArgs']]:
+        """
+        Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+        """
         return pulumi.get(self, "vpc_config")
 
     @vpc_config.setter
@@ -353,9 +453,43 @@ class Service(pulumi.CustomResource):
                  vpc_config: Optional[pulumi.Input[Union['ServiceVpcConfigArgs', 'ServiceVpcConfigArgsDict']]] = None,
                  __props__=None):
         """
-        Create a Service resource with the given unique name, props, and options.
+        Provides a Alicloud Function Compute Service resource. The resource is the base of launching Function and Trigger configuration.
+        For information about Service and how to use it, see [What is Function Compute](https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-createservice).
+
+        > **NOTE:** The resource requires a provider field 'account_id'. See account_id.
+
+        > **NOTE:** If you happen the error "Argument 'internetAccess' is not supported", you need to log on web console and click button "Apply VPC Function"
+        which is in the upper of [Function Service Web Console](https://fc.console.aliyun.com/) page.
+
+        > **NOTE:** Currently not all regions support Function Compute Service.
+        For more details supported regions, see [Service endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm)
+
+        > **NOTE:** Available since v1.93.0.
+        ## Module Support
+
+        You can use to the existing fc module to create a service and a function quickly and then set several triggers for it.
+
+        ## Import
+
+        Function Compute Service can be imported using the id or name, e.g.
+
+        ```sh
+        $ pulumi import alicloud:fc/service:Service foo my-fc-service
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[_builtins.str] description: The Function Compute Service description.
+        :param pulumi.Input[_builtins.bool] internet_access: Whether to allow the Service to access Internet. Default to "true".
+        :param pulumi.Input[Union['ServiceLogConfigArgs', 'ServiceLogConfigArgsDict']] log_config: Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        :param pulumi.Input[_builtins.str] name: The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        :param pulumi.Input[_builtins.str] name_prefix: Setting a prefix to get a only name. It is conflict with `name`.
+        :param pulumi.Input[Union['ServiceNasConfigArgs', 'ServiceNasConfigArgsDict']] nas_config: Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        :param pulumi.Input[_builtins.bool] publish: Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        :param pulumi.Input[_builtins.str] role: RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Map for tagging resources.
+        :param pulumi.Input[Union['ServiceTracingConfigArgs', 'ServiceTracingConfigArgsDict']] tracing_config: Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        :param pulumi.Input[Union['ServiceVpcConfigArgs', 'ServiceVpcConfigArgsDict']] vpc_config: Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
         """
         ...
     @overload
@@ -364,7 +498,30 @@ class Service(pulumi.CustomResource):
                  args: Optional[ServiceArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        Create a Service resource with the given unique name, props, and options.
+        Provides a Alicloud Function Compute Service resource. The resource is the base of launching Function and Trigger configuration.
+        For information about Service and how to use it, see [What is Function Compute](https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-createservice).
+
+        > **NOTE:** The resource requires a provider field 'account_id'. See account_id.
+
+        > **NOTE:** If you happen the error "Argument 'internetAccess' is not supported", you need to log on web console and click button "Apply VPC Function"
+        which is in the upper of [Function Service Web Console](https://fc.console.aliyun.com/) page.
+
+        > **NOTE:** Currently not all regions support Function Compute Service.
+        For more details supported regions, see [Service endpoints](https://www.alibabacloud.com/help/doc-detail/52984.htm)
+
+        > **NOTE:** Available since v1.93.0.
+        ## Module Support
+
+        You can use to the existing fc module to create a service and a function quickly and then set several triggers for it.
+
+        ## Import
+
+        Function Compute Service can be imported using the id or name, e.g.
+
+        ```sh
+        $ pulumi import alicloud:fc/service:Service foo my-fc-service
+        ```
+
         :param str resource_name: The name of the resource.
         :param ServiceArgs args: The arguments to use to populate this resource's properties.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -445,6 +602,20 @@ class Service(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[_builtins.str] description: The Function Compute Service description.
+        :param pulumi.Input[_builtins.bool] internet_access: Whether to allow the Service to access Internet. Default to "true".
+        :param pulumi.Input[_builtins.str] last_modified: The date this resource was last modified.
+        :param pulumi.Input[Union['ServiceLogConfigArgs', 'ServiceLogConfigArgsDict']] log_config: Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        :param pulumi.Input[_builtins.str] name: The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        :param pulumi.Input[_builtins.str] name_prefix: Setting a prefix to get a only name. It is conflict with `name`.
+        :param pulumi.Input[Union['ServiceNasConfigArgs', 'ServiceNasConfigArgsDict']] nas_config: Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        :param pulumi.Input[_builtins.bool] publish: Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        :param pulumi.Input[_builtins.str] role: RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        :param pulumi.Input[_builtins.str] service_id: The Function Compute Service ID.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Map for tagging resources.
+        :param pulumi.Input[Union['ServiceTracingConfigArgs', 'ServiceTracingConfigArgsDict']] tracing_config: Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        :param pulumi.Input[_builtins.str] version: The latest published version of your Function Compute Service.
+        :param pulumi.Input[Union['ServiceVpcConfigArgs', 'ServiceVpcConfigArgsDict']] vpc_config: Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -469,70 +640,112 @@ class Service(pulumi.CustomResource):
     @_builtins.property
     @pulumi.getter
     def description(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        The Function Compute Service description.
+        """
         return pulumi.get(self, "description")
 
     @_builtins.property
     @pulumi.getter(name="internetAccess")
     def internet_access(self) -> pulumi.Output[Optional[_builtins.bool]]:
+        """
+        Whether to allow the Service to access Internet. Default to "true".
+        """
         return pulumi.get(self, "internet_access")
 
     @_builtins.property
     @pulumi.getter(name="lastModified")
     def last_modified(self) -> pulumi.Output[_builtins.str]:
+        """
+        The date this resource was last modified.
+        """
         return pulumi.get(self, "last_modified")
 
     @_builtins.property
     @pulumi.getter(name="logConfig")
     def log_config(self) -> pulumi.Output[Optional['outputs.ServiceLogConfig']]:
+        """
+        Provide this to store your Function Compute Service logs. Fields documented below. See [Create a Service](https://www.alibabacloud.com/help/doc-detail/51924.htm). `log_config` requires the following: (**NOTE:** If both `project` and `logstore` are empty, log_config is considered to be empty or unset.). See `log_config` below.
+        """
         return pulumi.get(self, "log_config")
 
     @_builtins.property
     @pulumi.getter
     def name(self) -> pulumi.Output[_builtins.str]:
+        """
+        The Function Compute Service name. It is the only in one Alicloud account and is conflict with `name_prefix`.
+        """
         return pulumi.get(self, "name")
 
     @_builtins.property
     @pulumi.getter(name="namePrefix")
     def name_prefix(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        Setting a prefix to get a only name. It is conflict with `name`.
+        """
         return pulumi.get(self, "name_prefix")
 
     @_builtins.property
     @pulumi.getter(name="nasConfig")
     def nas_config(self) -> pulumi.Output[Optional['outputs.ServiceNasConfig']]:
+        """
+        Provide [NAS configuration](https://www.alibabacloud.com/help/doc-detail/87401.htm) to allow Function Compute Service to access your NAS resources. See `nas_config` below.
+        """
         return pulumi.get(self, "nas_config")
 
     @_builtins.property
     @pulumi.getter
     def publish(self) -> pulumi.Output[Optional[_builtins.bool]]:
+        """
+        Whether to publish creation/change as new Function Compute Service Version. Defaults to `false`.
+        """
         return pulumi.get(self, "publish")
 
     @_builtins.property
     @pulumi.getter
     def role(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        RAM role arn attached to the Function Compute Service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
+        """
         return pulumi.get(self, "role")
 
     @_builtins.property
     @pulumi.getter(name="serviceId")
     def service_id(self) -> pulumi.Output[_builtins.str]:
+        """
+        The Function Compute Service ID.
+        """
         return pulumi.get(self, "service_id")
 
     @_builtins.property
     @pulumi.getter
     def tags(self) -> pulumi.Output[Optional[Mapping[str, _builtins.str]]]:
+        """
+        Map for tagging resources.
+        """
         return pulumi.get(self, "tags")
 
     @_builtins.property
     @pulumi.getter(name="tracingConfig")
     def tracing_config(self) -> pulumi.Output[Optional['outputs.ServiceTracingConfig']]:
+        """
+        Provide this to allow your Function Compute to report tracing information. Fields documented below. See [Function Compute Tracing Config](https://help.aliyun.com/document_detail/189805.html). `tracing_config` requires the following: (**NOTE:** If both `type` and `params` are empty, tracing_config is considered to be empty or unset.). See `tracing_config` below.
+        """
         return pulumi.get(self, "tracing_config")
 
     @_builtins.property
     @pulumi.getter
     def version(self) -> pulumi.Output[_builtins.str]:
+        """
+        The latest published version of your Function Compute Service.
+        """
         return pulumi.get(self, "version")
 
     @_builtins.property
     @pulumi.getter(name="vpcConfig")
     def vpc_config(self) -> pulumi.Output[Optional['outputs.ServiceVpcConfig']]:
+        """
+        Provide this to allow your Function Compute Service to access your VPC. Fields documented below. See [Function Compute Service in VPC](https://www.alibabacloud.com/help/faq-detail/72959.htm). `vpc_config` requires the following: (**NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config is considered to be empty or unset.). See `vpc_config` below.
+        """
         return pulumi.get(self, "vpc_config")
 

--- a/sdk/python/pulumi_alicloud/fc/v2_function.py
+++ b/sdk/python/pulumi_alicloud/fc/v2_function.py
@@ -47,6 +47,36 @@ class V2FunctionArgs:
                  timeout: Optional[pulumi.Input[_builtins.int]] = None):
         """
         The set of arguments for constructing a V2Function resource.
+        :param pulumi.Input[_builtins.str] function_name: function name.
+        :param pulumi.Input[_builtins.str] handler: entry point of function.
+        :param pulumi.Input[_builtins.str] runtime: runtime of function code.
+        :param pulumi.Input[_builtins.str] service_name: The name of the function Service.
+        :param pulumi.Input[_builtins.int] ca_port: The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        :param pulumi.Input['V2FunctionCodeArgs'] code: Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        :param pulumi.Input[_builtins.str] code_checksum: crc64 of function code.
+        :param pulumi.Input[_builtins.float] cpu: The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        :param pulumi.Input['V2FunctionCustomContainerConfigArgs'] custom_container_config: Custom-container runtime related function configuration. See `custom_container_config` below.
+        :param pulumi.Input['V2FunctionCustomDnsArgs'] custom_dns: Function custom DNS configuration. See `custom_dns` below.
+        :param pulumi.Input['V2FunctionCustomHealthCheckConfigArgs'] custom_health_check_config: Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        :param pulumi.Input['V2FunctionCustomRuntimeConfigArgs'] custom_runtime_config: Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        :param pulumi.Input[_builtins.str] description: description of function.
+        :param pulumi.Input[_builtins.int] disk_size: The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] environment_variables: The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        :param pulumi.Input[_builtins.int] gpu_memory_size: The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        :param pulumi.Input[_builtins.int] initialization_timeout: max running time of initializer.
+        :param pulumi.Input[_builtins.str] initializer: initializer entry point of function.
+        :param pulumi.Input[_builtins.int] instance_concurrency: The maximum concurrency allowed for a single function instance.
+        :param pulumi.Input['V2FunctionInstanceLifecycleConfigArgs'] instance_lifecycle_config: Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        :param pulumi.Input[_builtins.str] instance_type: The instance type of the function. Valid values:
+               - **e1**: Elastic instance.
+               - **c1**: performance instance.
+               - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+               - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+               - **g1**: Same as **fc.gpu.tesla.1**.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] layers: List of layers.
+               > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        :param pulumi.Input[_builtins.int] memory_size: memory size needed by function.
+        :param pulumi.Input[_builtins.int] timeout: max running time of function.
         """
         pulumi.set(__self__, "function_name", function_name)
         pulumi.set(__self__, "handler", handler)
@@ -96,6 +126,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="functionName")
     def function_name(self) -> pulumi.Input[_builtins.str]:
+        """
+        function name.
+        """
         return pulumi.get(self, "function_name")
 
     @function_name.setter
@@ -105,6 +138,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def handler(self) -> pulumi.Input[_builtins.str]:
+        """
+        entry point of function.
+        """
         return pulumi.get(self, "handler")
 
     @handler.setter
@@ -114,6 +150,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def runtime(self) -> pulumi.Input[_builtins.str]:
+        """
+        runtime of function code.
+        """
         return pulumi.get(self, "runtime")
 
     @runtime.setter
@@ -123,6 +162,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="serviceName")
     def service_name(self) -> pulumi.Input[_builtins.str]:
+        """
+        The name of the function Service.
+        """
         return pulumi.get(self, "service_name")
 
     @service_name.setter
@@ -132,6 +174,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="caPort")
     def ca_port(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        """
         return pulumi.get(self, "ca_port")
 
     @ca_port.setter
@@ -141,6 +186,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def code(self) -> Optional[pulumi.Input['V2FunctionCodeArgs']]:
+        """
+        Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        """
         return pulumi.get(self, "code")
 
     @code.setter
@@ -150,6 +198,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="codeChecksum")
     def code_checksum(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        crc64 of function code.
+        """
         return pulumi.get(self, "code_checksum")
 
     @code_checksum.setter
@@ -159,6 +210,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def cpu(self) -> Optional[pulumi.Input[_builtins.float]]:
+        """
+        The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        """
         return pulumi.get(self, "cpu")
 
     @cpu.setter
@@ -168,6 +222,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="customContainerConfig")
     def custom_container_config(self) -> Optional[pulumi.Input['V2FunctionCustomContainerConfigArgs']]:
+        """
+        Custom-container runtime related function configuration. See `custom_container_config` below.
+        """
         return pulumi.get(self, "custom_container_config")
 
     @custom_container_config.setter
@@ -177,6 +234,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="customDns")
     def custom_dns(self) -> Optional[pulumi.Input['V2FunctionCustomDnsArgs']]:
+        """
+        Function custom DNS configuration. See `custom_dns` below.
+        """
         return pulumi.get(self, "custom_dns")
 
     @custom_dns.setter
@@ -186,6 +246,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="customHealthCheckConfig")
     def custom_health_check_config(self) -> Optional[pulumi.Input['V2FunctionCustomHealthCheckConfigArgs']]:
+        """
+        Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        """
         return pulumi.get(self, "custom_health_check_config")
 
     @custom_health_check_config.setter
@@ -195,6 +258,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="customRuntimeConfig")
     def custom_runtime_config(self) -> Optional[pulumi.Input['V2FunctionCustomRuntimeConfigArgs']]:
+        """
+        Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        """
         return pulumi.get(self, "custom_runtime_config")
 
     @custom_runtime_config.setter
@@ -204,6 +270,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        description of function.
+        """
         return pulumi.get(self, "description")
 
     @description.setter
@@ -213,6 +282,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="diskSize")
     def disk_size(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        """
         return pulumi.get(self, "disk_size")
 
     @disk_size.setter
@@ -222,6 +294,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="environmentVariables")
     def environment_variables(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]:
+        """
+        The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        """
         return pulumi.get(self, "environment_variables")
 
     @environment_variables.setter
@@ -231,6 +306,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="gpuMemorySize")
     def gpu_memory_size(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        """
         return pulumi.get(self, "gpu_memory_size")
 
     @gpu_memory_size.setter
@@ -240,6 +318,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="initializationTimeout")
     def initialization_timeout(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        max running time of initializer.
+        """
         return pulumi.get(self, "initialization_timeout")
 
     @initialization_timeout.setter
@@ -249,6 +330,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def initializer(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        initializer entry point of function.
+        """
         return pulumi.get(self, "initializer")
 
     @initializer.setter
@@ -258,6 +342,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="instanceConcurrency")
     def instance_concurrency(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The maximum concurrency allowed for a single function instance.
+        """
         return pulumi.get(self, "instance_concurrency")
 
     @instance_concurrency.setter
@@ -267,6 +354,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="instanceLifecycleConfig")
     def instance_lifecycle_config(self) -> Optional[pulumi.Input['V2FunctionInstanceLifecycleConfigArgs']]:
+        """
+        Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        """
         return pulumi.get(self, "instance_lifecycle_config")
 
     @instance_lifecycle_config.setter
@@ -276,6 +366,14 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The instance type of the function. Valid values:
+        - **e1**: Elastic instance.
+        - **c1**: performance instance.
+        - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+        - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+        - **g1**: Same as **fc.gpu.tesla.1**.
+        """
         return pulumi.get(self, "instance_type")
 
     @instance_type.setter
@@ -285,6 +383,10 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def layers(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+        """
+        List of layers.
+        > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        """
         return pulumi.get(self, "layers")
 
     @layers.setter
@@ -294,6 +396,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter(name="memorySize")
     def memory_size(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        memory size needed by function.
+        """
         return pulumi.get(self, "memory_size")
 
     @memory_size.setter
@@ -303,6 +408,9 @@ class V2FunctionArgs:
     @_builtins.property
     @pulumi.getter
     def timeout(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        max running time of function.
+        """
         return pulumi.get(self, "timeout")
 
     @timeout.setter
@@ -341,6 +449,38 @@ class _V2FunctionState:
                  timeout: Optional[pulumi.Input[_builtins.int]] = None):
         """
         Input properties used for looking up and filtering V2Function resources.
+        :param pulumi.Input[_builtins.int] ca_port: The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        :param pulumi.Input['V2FunctionCodeArgs'] code: Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        :param pulumi.Input[_builtins.str] code_checksum: crc64 of function code.
+        :param pulumi.Input[_builtins.float] cpu: The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        :param pulumi.Input[_builtins.str] create_time: create time of function.
+        :param pulumi.Input['V2FunctionCustomContainerConfigArgs'] custom_container_config: Custom-container runtime related function configuration. See `custom_container_config` below.
+        :param pulumi.Input['V2FunctionCustomDnsArgs'] custom_dns: Function custom DNS configuration. See `custom_dns` below.
+        :param pulumi.Input['V2FunctionCustomHealthCheckConfigArgs'] custom_health_check_config: Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        :param pulumi.Input['V2FunctionCustomRuntimeConfigArgs'] custom_runtime_config: Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        :param pulumi.Input[_builtins.str] description: description of function.
+        :param pulumi.Input[_builtins.int] disk_size: The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] environment_variables: The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        :param pulumi.Input[_builtins.str] function_arn: The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+        :param pulumi.Input[_builtins.str] function_name: function name.
+        :param pulumi.Input[_builtins.int] gpu_memory_size: The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        :param pulumi.Input[_builtins.str] handler: entry point of function.
+        :param pulumi.Input[_builtins.int] initialization_timeout: max running time of initializer.
+        :param pulumi.Input[_builtins.str] initializer: initializer entry point of function.
+        :param pulumi.Input[_builtins.int] instance_concurrency: The maximum concurrency allowed for a single function instance.
+        :param pulumi.Input['V2FunctionInstanceLifecycleConfigArgs'] instance_lifecycle_config: Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        :param pulumi.Input[_builtins.str] instance_type: The instance type of the function. Valid values:
+               - **e1**: Elastic instance.
+               - **c1**: performance instance.
+               - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+               - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+               - **g1**: Same as **fc.gpu.tesla.1**.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] layers: List of layers.
+               > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        :param pulumi.Input[_builtins.int] memory_size: memory size needed by function.
+        :param pulumi.Input[_builtins.str] runtime: runtime of function code.
+        :param pulumi.Input[_builtins.str] service_name: The name of the function Service.
+        :param pulumi.Input[_builtins.int] timeout: max running time of function.
         """
         if ca_port is not None:
             pulumi.set(__self__, "ca_port", ca_port)
@@ -398,6 +538,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="caPort")
     def ca_port(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        """
         return pulumi.get(self, "ca_port")
 
     @ca_port.setter
@@ -407,6 +550,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def code(self) -> Optional[pulumi.Input['V2FunctionCodeArgs']]:
+        """
+        Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        """
         return pulumi.get(self, "code")
 
     @code.setter
@@ -416,6 +562,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="codeChecksum")
     def code_checksum(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        crc64 of function code.
+        """
         return pulumi.get(self, "code_checksum")
 
     @code_checksum.setter
@@ -425,6 +574,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def cpu(self) -> Optional[pulumi.Input[_builtins.float]]:
+        """
+        The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        """
         return pulumi.get(self, "cpu")
 
     @cpu.setter
@@ -434,6 +586,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="createTime")
     def create_time(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        create time of function.
+        """
         return pulumi.get(self, "create_time")
 
     @create_time.setter
@@ -443,6 +598,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="customContainerConfig")
     def custom_container_config(self) -> Optional[pulumi.Input['V2FunctionCustomContainerConfigArgs']]:
+        """
+        Custom-container runtime related function configuration. See `custom_container_config` below.
+        """
         return pulumi.get(self, "custom_container_config")
 
     @custom_container_config.setter
@@ -452,6 +610,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="customDns")
     def custom_dns(self) -> Optional[pulumi.Input['V2FunctionCustomDnsArgs']]:
+        """
+        Function custom DNS configuration. See `custom_dns` below.
+        """
         return pulumi.get(self, "custom_dns")
 
     @custom_dns.setter
@@ -461,6 +622,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="customHealthCheckConfig")
     def custom_health_check_config(self) -> Optional[pulumi.Input['V2FunctionCustomHealthCheckConfigArgs']]:
+        """
+        Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        """
         return pulumi.get(self, "custom_health_check_config")
 
     @custom_health_check_config.setter
@@ -470,6 +634,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="customRuntimeConfig")
     def custom_runtime_config(self) -> Optional[pulumi.Input['V2FunctionCustomRuntimeConfigArgs']]:
+        """
+        Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        """
         return pulumi.get(self, "custom_runtime_config")
 
     @custom_runtime_config.setter
@@ -479,6 +646,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        description of function.
+        """
         return pulumi.get(self, "description")
 
     @description.setter
@@ -488,6 +658,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="diskSize")
     def disk_size(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        """
         return pulumi.get(self, "disk_size")
 
     @disk_size.setter
@@ -497,6 +670,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="environmentVariables")
     def environment_variables(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]:
+        """
+        The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        """
         return pulumi.get(self, "environment_variables")
 
     @environment_variables.setter
@@ -506,6 +682,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="functionArn")
     def function_arn(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+        """
         return pulumi.get(self, "function_arn")
 
     @function_arn.setter
@@ -515,6 +694,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="functionName")
     def function_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        function name.
+        """
         return pulumi.get(self, "function_name")
 
     @function_name.setter
@@ -524,6 +706,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="gpuMemorySize")
     def gpu_memory_size(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        """
         return pulumi.get(self, "gpu_memory_size")
 
     @gpu_memory_size.setter
@@ -533,6 +718,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def handler(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        entry point of function.
+        """
         return pulumi.get(self, "handler")
 
     @handler.setter
@@ -542,6 +730,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="initializationTimeout")
     def initialization_timeout(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        max running time of initializer.
+        """
         return pulumi.get(self, "initialization_timeout")
 
     @initialization_timeout.setter
@@ -551,6 +742,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def initializer(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        initializer entry point of function.
+        """
         return pulumi.get(self, "initializer")
 
     @initializer.setter
@@ -560,6 +754,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="instanceConcurrency")
     def instance_concurrency(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        The maximum concurrency allowed for a single function instance.
+        """
         return pulumi.get(self, "instance_concurrency")
 
     @instance_concurrency.setter
@@ -569,6 +766,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="instanceLifecycleConfig")
     def instance_lifecycle_config(self) -> Optional[pulumi.Input['V2FunctionInstanceLifecycleConfigArgs']]:
+        """
+        Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        """
         return pulumi.get(self, "instance_lifecycle_config")
 
     @instance_lifecycle_config.setter
@@ -578,6 +778,14 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The instance type of the function. Valid values:
+        - **e1**: Elastic instance.
+        - **c1**: performance instance.
+        - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+        - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+        - **g1**: Same as **fc.gpu.tesla.1**.
+        """
         return pulumi.get(self, "instance_type")
 
     @instance_type.setter
@@ -587,6 +795,10 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def layers(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
+        """
+        List of layers.
+        > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        """
         return pulumi.get(self, "layers")
 
     @layers.setter
@@ -596,6 +808,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="memorySize")
     def memory_size(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        memory size needed by function.
+        """
         return pulumi.get(self, "memory_size")
 
     @memory_size.setter
@@ -605,6 +820,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def runtime(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        runtime of function code.
+        """
         return pulumi.get(self, "runtime")
 
     @runtime.setter
@@ -614,6 +832,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter(name="serviceName")
     def service_name(self) -> Optional[pulumi.Input[_builtins.str]]:
+        """
+        The name of the function Service.
+        """
         return pulumi.get(self, "service_name")
 
     @service_name.setter
@@ -623,6 +844,9 @@ class _V2FunctionState:
     @_builtins.property
     @pulumi.getter
     def timeout(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        max running time of function.
+        """
         return pulumi.get(self, "timeout")
 
     @timeout.setter
@@ -662,9 +886,52 @@ class V2Function(pulumi.CustomResource):
                  timeout: Optional[pulumi.Input[_builtins.int]] = None,
                  __props__=None):
         """
-        Create a V2Function resource with the given unique name, props, and options.
+        Provides a FCV2 Function resource. Function is the unit of system scheduling and operation. Functions must be subordinate to services. All functions under the same service share some identical settings, such as service authorization and log configuration.
+
+        For information about FCV2 Function and how to use it, see [What is Function](https://www.alibabacloud.com/help/en/resource-orchestration-service/latest/aliyun-fc-function).
+
+        > **NOTE:** Available since v1.208.0.
+
+        ## Import
+
+        FCV2 Function can be imported using the id, e.g.
+
+        ```sh
+        $ pulumi import alicloud:fc/v2Function:V2Function example <service_name>:<function_name>
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[_builtins.int] ca_port: The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        :param pulumi.Input[Union['V2FunctionCodeArgs', 'V2FunctionCodeArgsDict']] code: Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        :param pulumi.Input[_builtins.str] code_checksum: crc64 of function code.
+        :param pulumi.Input[_builtins.float] cpu: The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        :param pulumi.Input[Union['V2FunctionCustomContainerConfigArgs', 'V2FunctionCustomContainerConfigArgsDict']] custom_container_config: Custom-container runtime related function configuration. See `custom_container_config` below.
+        :param pulumi.Input[Union['V2FunctionCustomDnsArgs', 'V2FunctionCustomDnsArgsDict']] custom_dns: Function custom DNS configuration. See `custom_dns` below.
+        :param pulumi.Input[Union['V2FunctionCustomHealthCheckConfigArgs', 'V2FunctionCustomHealthCheckConfigArgsDict']] custom_health_check_config: Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        :param pulumi.Input[Union['V2FunctionCustomRuntimeConfigArgs', 'V2FunctionCustomRuntimeConfigArgsDict']] custom_runtime_config: Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        :param pulumi.Input[_builtins.str] description: description of function.
+        :param pulumi.Input[_builtins.int] disk_size: The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] environment_variables: The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        :param pulumi.Input[_builtins.str] function_name: function name.
+        :param pulumi.Input[_builtins.int] gpu_memory_size: The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        :param pulumi.Input[_builtins.str] handler: entry point of function.
+        :param pulumi.Input[_builtins.int] initialization_timeout: max running time of initializer.
+        :param pulumi.Input[_builtins.str] initializer: initializer entry point of function.
+        :param pulumi.Input[_builtins.int] instance_concurrency: The maximum concurrency allowed for a single function instance.
+        :param pulumi.Input[Union['V2FunctionInstanceLifecycleConfigArgs', 'V2FunctionInstanceLifecycleConfigArgsDict']] instance_lifecycle_config: Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        :param pulumi.Input[_builtins.str] instance_type: The instance type of the function. Valid values:
+               - **e1**: Elastic instance.
+               - **c1**: performance instance.
+               - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+               - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+               - **g1**: Same as **fc.gpu.tesla.1**.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] layers: List of layers.
+               > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        :param pulumi.Input[_builtins.int] memory_size: memory size needed by function.
+        :param pulumi.Input[_builtins.str] runtime: runtime of function code.
+        :param pulumi.Input[_builtins.str] service_name: The name of the function Service.
+        :param pulumi.Input[_builtins.int] timeout: max running time of function.
         """
         ...
     @overload
@@ -673,7 +940,20 @@ class V2Function(pulumi.CustomResource):
                  args: V2FunctionArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        Create a V2Function resource with the given unique name, props, and options.
+        Provides a FCV2 Function resource. Function is the unit of system scheduling and operation. Functions must be subordinate to services. All functions under the same service share some identical settings, such as service authorization and log configuration.
+
+        For information about FCV2 Function and how to use it, see [What is Function](https://www.alibabacloud.com/help/en/resource-orchestration-service/latest/aliyun-fc-function).
+
+        > **NOTE:** Available since v1.208.0.
+
+        ## Import
+
+        FCV2 Function can be imported using the id, e.g.
+
+        ```sh
+        $ pulumi import alicloud:fc/v2Function:V2Function example <service_name>:<function_name>
+        ```
+
         :param str resource_name: The name of the resource.
         :param V2FunctionArgs args: The arguments to use to populate this resource's properties.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -799,6 +1079,38 @@ class V2Function(pulumi.CustomResource):
         :param str resource_name: The unique name of the resulting resource.
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[_builtins.int] ca_port: The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        :param pulumi.Input[Union['V2FunctionCodeArgs', 'V2FunctionCodeArgsDict']] code: Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        :param pulumi.Input[_builtins.str] code_checksum: crc64 of function code.
+        :param pulumi.Input[_builtins.float] cpu: The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        :param pulumi.Input[_builtins.str] create_time: create time of function.
+        :param pulumi.Input[Union['V2FunctionCustomContainerConfigArgs', 'V2FunctionCustomContainerConfigArgsDict']] custom_container_config: Custom-container runtime related function configuration. See `custom_container_config` below.
+        :param pulumi.Input[Union['V2FunctionCustomDnsArgs', 'V2FunctionCustomDnsArgsDict']] custom_dns: Function custom DNS configuration. See `custom_dns` below.
+        :param pulumi.Input[Union['V2FunctionCustomHealthCheckConfigArgs', 'V2FunctionCustomHealthCheckConfigArgsDict']] custom_health_check_config: Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        :param pulumi.Input[Union['V2FunctionCustomRuntimeConfigArgs', 'V2FunctionCustomRuntimeConfigArgsDict']] custom_runtime_config: Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        :param pulumi.Input[_builtins.str] description: description of function.
+        :param pulumi.Input[_builtins.int] disk_size: The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] environment_variables: The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        :param pulumi.Input[_builtins.str] function_arn: The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+        :param pulumi.Input[_builtins.str] function_name: function name.
+        :param pulumi.Input[_builtins.int] gpu_memory_size: The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        :param pulumi.Input[_builtins.str] handler: entry point of function.
+        :param pulumi.Input[_builtins.int] initialization_timeout: max running time of initializer.
+        :param pulumi.Input[_builtins.str] initializer: initializer entry point of function.
+        :param pulumi.Input[_builtins.int] instance_concurrency: The maximum concurrency allowed for a single function instance.
+        :param pulumi.Input[Union['V2FunctionInstanceLifecycleConfigArgs', 'V2FunctionInstanceLifecycleConfigArgsDict']] instance_lifecycle_config: Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        :param pulumi.Input[_builtins.str] instance_type: The instance type of the function. Valid values:
+               - **e1**: Elastic instance.
+               - **c1**: performance instance.
+               - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+               - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+               - **g1**: Same as **fc.gpu.tesla.1**.
+        :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] layers: List of layers.
+               > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        :param pulumi.Input[_builtins.int] memory_size: memory size needed by function.
+        :param pulumi.Input[_builtins.str] runtime: runtime of function code.
+        :param pulumi.Input[_builtins.str] service_name: The name of the function Service.
+        :param pulumi.Input[_builtins.int] timeout: max running time of function.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -835,130 +1147,214 @@ class V2Function(pulumi.CustomResource):
     @_builtins.property
     @pulumi.getter(name="caPort")
     def ca_port(self) -> pulumi.Output[_builtins.int]:
+        """
+        The listening port of the HTTP Server when the Custom Runtime or Custom Container is running.
+        """
         return pulumi.get(self, "ca_port")
 
     @_builtins.property
     @pulumi.getter
     def code(self) -> pulumi.Output[Optional['outputs.V2FunctionCode']]:
+        """
+        Function Code ZIP package. code and customContainerConfig choose one. See `code` below.
+        """
         return pulumi.get(self, "code")
 
     @_builtins.property
     @pulumi.getter(name="codeChecksum")
     def code_checksum(self) -> pulumi.Output[_builtins.str]:
+        """
+        crc64 of function code.
+        """
         return pulumi.get(self, "code_checksum")
 
     @_builtins.property
     @pulumi.getter
     def cpu(self) -> pulumi.Output[Optional[_builtins.float]]:
+        """
+        The CPU specification of the function. The unit is vCPU, which is a multiple of the 0.05 vCPU.
+        """
         return pulumi.get(self, "cpu")
 
     @_builtins.property
     @pulumi.getter(name="createTime")
     def create_time(self) -> pulumi.Output[_builtins.str]:
+        """
+        create time of function.
+        """
         return pulumi.get(self, "create_time")
 
     @_builtins.property
     @pulumi.getter(name="customContainerConfig")
     def custom_container_config(self) -> pulumi.Output[Optional['outputs.V2FunctionCustomContainerConfig']]:
+        """
+        Custom-container runtime related function configuration. See `custom_container_config` below.
+        """
         return pulumi.get(self, "custom_container_config")
 
     @_builtins.property
     @pulumi.getter(name="customDns")
     def custom_dns(self) -> pulumi.Output[Optional['outputs.V2FunctionCustomDns']]:
+        """
+        Function custom DNS configuration. See `custom_dns` below.
+        """
         return pulumi.get(self, "custom_dns")
 
     @_builtins.property
     @pulumi.getter(name="customHealthCheckConfig")
     def custom_health_check_config(self) -> pulumi.Output[Optional['outputs.V2FunctionCustomHealthCheckConfig']]:
+        """
+        Custom runtime/container Custom health check configuration. See `custom_health_check_config` below.
+        """
         return pulumi.get(self, "custom_health_check_config")
 
     @_builtins.property
     @pulumi.getter(name="customRuntimeConfig")
     def custom_runtime_config(self) -> pulumi.Output[Optional['outputs.V2FunctionCustomRuntimeConfig']]:
+        """
+        Detailed configuration of Custom Runtime function. See `custom_runtime_config` below.
+        """
         return pulumi.get(self, "custom_runtime_config")
 
     @_builtins.property
     @pulumi.getter
     def description(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        description of function.
+        """
         return pulumi.get(self, "description")
 
     @_builtins.property
     @pulumi.getter(name="diskSize")
     def disk_size(self) -> pulumi.Output[Optional[_builtins.int]]:
+        """
+        The disk specification of the function. The unit is MB. The optional value is 512 MB or 10240MB.
+        """
         return pulumi.get(self, "disk_size")
 
     @_builtins.property
     @pulumi.getter(name="environmentVariables")
     def environment_variables(self) -> pulumi.Output[Optional[Mapping[str, _builtins.str]]]:
+        """
+        The environment variable set for the function can get the value of the environment variable in the function. For more information, see Environment Variables.
+        """
         return pulumi.get(self, "environment_variables")
 
     @_builtins.property
     @pulumi.getter(name="functionArn")
     def function_arn(self) -> pulumi.Output[_builtins.str]:
+        """
+        The Function Compute service function arn. It formats as `acs:fc:<region>:<uid>:services/<serviceName>.LATEST/functions/<functionName>`.
+        """
         return pulumi.get(self, "function_arn")
 
     @_builtins.property
     @pulumi.getter(name="functionName")
     def function_name(self) -> pulumi.Output[_builtins.str]:
+        """
+        function name.
+        """
         return pulumi.get(self, "function_name")
 
     @_builtins.property
     @pulumi.getter(name="gpuMemorySize")
     def gpu_memory_size(self) -> pulumi.Output[Optional[_builtins.int]]:
+        """
+        The GPU memory specification of the function, in MB, is a multiple of 1024MB.
+        """
         return pulumi.get(self, "gpu_memory_size")
 
     @_builtins.property
     @pulumi.getter
     def handler(self) -> pulumi.Output[_builtins.str]:
+        """
+        entry point of function.
+        """
         return pulumi.get(self, "handler")
 
     @_builtins.property
     @pulumi.getter(name="initializationTimeout")
     def initialization_timeout(self) -> pulumi.Output[_builtins.int]:
+        """
+        max running time of initializer.
+        """
         return pulumi.get(self, "initialization_timeout")
 
     @_builtins.property
     @pulumi.getter
     def initializer(self) -> pulumi.Output[Optional[_builtins.str]]:
+        """
+        initializer entry point of function.
+        """
         return pulumi.get(self, "initializer")
 
     @_builtins.property
     @pulumi.getter(name="instanceConcurrency")
     def instance_concurrency(self) -> pulumi.Output[_builtins.int]:
+        """
+        The maximum concurrency allowed for a single function instance.
+        """
         return pulumi.get(self, "instance_concurrency")
 
     @_builtins.property
     @pulumi.getter(name="instanceLifecycleConfig")
     def instance_lifecycle_config(self) -> pulumi.Output[Optional['outputs.V2FunctionInstanceLifecycleConfig']]:
+        """
+        Instance lifecycle configuration. See `instance_lifecycle_config` below.
+        """
         return pulumi.get(self, "instance_lifecycle_config")
 
     @_builtins.property
     @pulumi.getter(name="instanceType")
     def instance_type(self) -> pulumi.Output[_builtins.str]:
+        """
+        The instance type of the function. Valid values:
+        - **e1**: Elastic instance.
+        - **c1**: performance instance.
+        - **fc.gpu.tesla.1**: the T4 card type of the Tesla series of GPU instances.
+        - **fc.gpu.ampere.1**: The Ampere series A10 card type of the GPU instance.
+        - **g1**: Same as **fc.gpu.tesla.1**.
+        """
         return pulumi.get(self, "instance_type")
 
     @_builtins.property
     @pulumi.getter
     def layers(self) -> pulumi.Output[Optional[Sequence[_builtins.str]]]:
+        """
+        List of layers.
+        > **NOTE:**  Multiple layers will be merged in the order of array subscripts from large to small, and the contents of layers with small subscripts will overwrite the files with the same name of layers with large subscripts.
+        """
         return pulumi.get(self, "layers")
 
     @_builtins.property
     @pulumi.getter(name="memorySize")
     def memory_size(self) -> pulumi.Output[_builtins.int]:
+        """
+        memory size needed by function.
+        """
         return pulumi.get(self, "memory_size")
 
     @_builtins.property
     @pulumi.getter
     def runtime(self) -> pulumi.Output[_builtins.str]:
+        """
+        runtime of function code.
+        """
         return pulumi.get(self, "runtime")
 
     @_builtins.property
     @pulumi.getter(name="serviceName")
     def service_name(self) -> pulumi.Output[_builtins.str]:
+        """
+        The name of the function Service.
+        """
         return pulumi.get(self, "service_name")
 
     @_builtins.property
     @pulumi.getter
     def timeout(self) -> pulumi.Output[_builtins.int]:
+        """
+        max running time of function.
+        """
         return pulumi.get(self, "timeout")
 


### PR DESCRIPTION
This pull request moves away from using the SkipExamples experimental bridge feature and uses DocsEdit instead.

Prerequisite for https://github.com/pulumi/pulumi-terraform-bridge/issues/3152.

- **FC Service and vsFunction: Elide examples section via docsEdit and remove SkipExamples use**
- **generate SDK**
